### PR TITLE
remove double-nested properties in geojson

### DIFF
--- a/code/csv_to_geojson.js
+++ b/code/csv_to_geojson.js
@@ -7,12 +7,12 @@ const data = [];
 fs.createReadStream('data/permits_lat_long.csv')
   .pipe(csv())
   .on('data', (row) => {
-    // Assuming your CSV has 'latitude' and 'longitude' columns
-    data.push({
-      lat: parseFloat(row.lat),
-      lng: parseFloat(row.lng),
-      properties: row
-    });
+    // Convert latitude and longitude to numbers    
+      row.lat = parseFloat(row.lat);
+      row.lng = parseFloat(row.lng);
+
+    // Add the row directly to the data array
+      data.push(row);
   })
   .on('end', () => {
     const geoJson = GeoJSON.parse(data, {Point: ['lat', 'lng']});

--- a/code/heatmap.js
+++ b/code/heatmap.js
@@ -71,7 +71,7 @@ function jsonCallback(err, data) {
   }
 
   data.features = data.features.map((d) => {
-    d.properties.year = Number(d.properties.properties.year);
+    d.properties.year = Number(d.properties.year);
     return d;
   });
 

--- a/data/permits_lat_long.geojson
+++ b/data/permits_lat_long.geojson
@@ -11,21 +11,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C19-1175",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3800 ALUMNI DRIVE, Anchorage, Alaska",
-          "Parcel": "421101000",
-          "Units": "NA",
-          "Legal": "T13N R3W SEC 28 NE4NE4 G:1635",
-          "Valuation": "18000",
-          "formatted_address": "Administrative/Humanities Building, 3800 Alumni Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1918458",
-          "lng": "-149.8145754"
-        }
+        "Permit": "C19-1175",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3800 ALUMNI DRIVE, Anchorage, Alaska",
+        "Parcel": "421101000",
+        "Units": "NA",
+        "Legal": "T13N R3W SEC 28 NE4NE4 G:1635",
+        "Valuation": "18000",
+        "formatted_address": "Administrative/Humanities Building, 3800 Alumni Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -38,21 +34,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C19-1234",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1230 11TH, Anchorage, Alaska",
-          "Parcel": "108360000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 25A LT  13A  G:1329",
-          "Valuation": "15915",
-          "formatted_address": "1230 W 11th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2114152",
-          "lng": "-149.9070615"
-        }
+        "Permit": "C19-1234",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1230 11TH, Anchorage, Alaska",
+        "Parcel": "108360000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 25A LT  13A  G:1329",
+        "Valuation": "15915",
+        "formatted_address": "1230 W 11th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -65,21 +57,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C19-1489",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1008 30TH, Anchorage, Alaska",
-          "Parcel": "1001625000",
-          "Units": "NA",
-          "Legal": "NELS SAND TR  4 E50' & TR 5 W10'  G:1629",
-          "Valuation": "11151",
-          "formatted_address": "1008 W 30th Ave, Anchorage, AK 99503, USA",
-          "lat": "61.1929041",
-          "lng": "-149.9024792"
-        }
+        "Permit": "C19-1489",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1008 30TH, Anchorage, Alaska",
+        "Parcel": "1001625000",
+        "Units": "NA",
+        "Legal": "NELS SAND TR  4 E50' & TR 5 W10'  G:1629",
+        "Valuation": "11151",
+        "formatted_address": "1008 W 30th Ave, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -92,21 +80,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C19-1587",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2303 MC RAE, Anchorage, Alaska",
-          "Parcel": "1012317000",
-          "Units": "NA",
-          "Legal": "LINTNER LT 37  G:1728",
-          "Valuation": "21949",
-          "formatted_address": "2303 McRae Rd, Anchorage, AK 99517, USA",
-          "lat": "61.18604019999999",
-          "lng": "-149.9252181"
-        }
+        "Permit": "C19-1587",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2303 MC RAE, Anchorage, Alaska",
+        "Parcel": "1012317000",
+        "Units": "NA",
+        "Legal": "LINTNER LT 37  G:1728",
+        "Valuation": "21949",
+        "formatted_address": "2303 McRae Rd, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -119,21 +103,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C19-1662",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "14861 MOUNTAIN AIR, Anchorage, Alaska",
-          "Parcel": "1721134000",
-          "Units": "NA",
-          "Legal": "MOUNTAIN AIR ESTATES #2 TR  B1-A  G:3139",
-          "Valuation": "20000",
-          "formatted_address": "14861 Mountain Air Dr, Anchorage, AK 99516, USA",
-          "lat": "61.0861984",
-          "lng": "-149.752238"
-        }
+        "Permit": "C19-1662",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "14861 MOUNTAIN AIR, Anchorage, Alaska",
+        "Parcel": "1721134000",
+        "Units": "NA",
+        "Legal": "MOUNTAIN AIR ESTATES #2 TR  B1-A  G:3139",
+        "Valuation": "20000",
+        "formatted_address": "14861 Mountain Air Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -146,21 +126,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C19-1664",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "E 307 24TH, Anchorage, Alaska",
-          "Parcel": "220330000",
-          "Units": "NA",
-          "Legal": "PEARL V SMITH BLK  2 LT   7A  G:1531",
-          "Valuation": "17000",
-          "formatted_address": "307 E 24th Ave, Anchorage, AK 99503, USA",
-          "lat": "61.1993937",
-          "lng": "-149.8785276"
-        }
+        "Permit": "C19-1664",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "E 307 24TH, Anchorage, Alaska",
+        "Parcel": "220330000",
+        "Units": "NA",
+        "Legal": "PEARL V SMITH BLK  2 LT   7A  G:1531",
+        "Valuation": "17000",
+        "formatted_address": "307 E 24th Ave, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -173,21 +149,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1151",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "5840 DE ARMOUN, Anchorage, Alaska",
-          "Parcel": "1706103000",
-          "Units": "NA",
-          "Legal": "MOUNTAIN PARK ESTATES BLK  2 LT   3  G:2938",
-          "Valuation": "16000",
-          "formatted_address": "5840 De Armoun Rd, Anchorage, AK 99516, USA",
-          "lat": "61.098326900000004",
-          "lng": "-149.7729153"
-        }
+        "Permit": "R19-1151",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "5840 DE ARMOUN, Anchorage, Alaska",
+        "Parcel": "1706103000",
+        "Units": "NA",
+        "Legal": "MOUNTAIN PARK ESTATES BLK  2 LT   3  G:2938",
+        "Valuation": "16000",
+        "formatted_address": "5840 De Armoun Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -200,21 +172,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1152",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "220 PACIFIC VIEW, Anchorage, Alaska",
-          "Parcel": "1805119000",
-          "Units": "NA",
-          "Legal": "OCEAN VIEW WEST #1 BLK  2 LT   3  G:2830",
-          "Valuation": "20000",
-          "formatted_address": "220 Pacific View Dr, Anchorage, AK 99515, USA",
-          "lat": "61.1044563",
-          "lng": "-149.8832163"
-        }
+        "Permit": "R19-1152",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "220 PACIFIC VIEW, Anchorage, Alaska",
+        "Parcel": "1805119000",
+        "Units": "NA",
+        "Legal": "OCEAN VIEW WEST #1 BLK  2 LT   3  G:2830",
+        "Valuation": "20000",
+        "formatted_address": "220 Pacific View Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -227,21 +195,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1181",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1334 N, Anchorage, Alaska",
-          "Parcel": "109605000",
-          "Units": "NA",
-          "Legal": "VIEW RIDGE (OF SOUTH ADDN) BLK 34B LT",
-          "Valuation": "14396",
-          "formatted_address": "1334 N St, Anchorage, AK 99501, USA",
-          "lat": "61.2090018",
-          "lng": "-149.9082536"
-        }
+        "Permit": "R19-1181",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1334 N, Anchorage, Alaska",
+        "Parcel": "109605000",
+        "Units": "NA",
+        "Legal": "VIEW RIDGE (OF SOUTH ADDN) BLK 34B LT",
+        "Valuation": "14396",
+        "formatted_address": "1334 N St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -254,21 +218,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1182",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "10640 LONE TREE, Anchorage, Alaska",
-          "Parcel": "1532254000",
-          "Units": "NA",
-          "Legal": "VALLI VUE ESTATES #2 BLK  2 LT   4  G:2538",
-          "Valuation": "12744",
-          "formatted_address": "10640 Lone Tree Dr, Anchorage, AK 99507, USA",
-          "lat": "61.12357919999999",
-          "lng": "-149.7613002"
-        }
+        "Permit": "R19-1182",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "10640 LONE TREE, Anchorage, Alaska",
+        "Parcel": "1532254000",
+        "Units": "NA",
+        "Legal": "VALLI VUE ESTATES #2 BLK  2 LT   4  G:2538",
+        "Valuation": "12744",
+        "formatted_address": "10640 Lone Tree Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -281,21 +241,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1183",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "9400 SUGAR CIRCLE, Anchorage, Alaska",
-          "Parcel": "1509327000",
-          "Units": "NA",
-          "Legal": "CONIFER HEIGHTS BLK   2 LT 10  G:2440",
-          "Valuation": "13836",
-          "formatted_address": "9400 Sugar Cir, Anchorage, AK 99507, USA",
-          "lat": "61.13546909999999",
-          "lng": "-149.7320568"
-        }
+        "Permit": "R19-1183",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "9400 SUGAR CIRCLE, Anchorage, Alaska",
+        "Parcel": "1509327000",
+        "Units": "NA",
+        "Legal": "CONIFER HEIGHTS BLK   2 LT 10  G:2440",
+        "Valuation": "13836",
+        "formatted_address": "9400 Sugar Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -308,21 +264,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1185",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3737 COVENTRY, Anchorage, Alaska",
-          "Parcel": "1423335000",
-          "Units": "NA",
-          "Legal": "WINCHESTER HEIGHTS BLK  4 LT  11  G:2235",
-          "Valuation": "12903",
-          "formatted_address": "3737 Coventry Dr, Anchorage, AK 99507, USA",
-          "lat": "61.14565049999999",
-          "lng": "-149.8132932"
-        }
+        "Permit": "R19-1185",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3737 COVENTRY, Anchorage, Alaska",
+        "Parcel": "1423335000",
+        "Units": "NA",
+        "Legal": "WINCHESTER HEIGHTS BLK  4 LT  11  G:2235",
+        "Valuation": "12903",
+        "formatted_address": "3737 Coventry Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -335,21 +287,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1191",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2022 BRANDILYN, Anchorage, Alaska",
-          "Parcel": "1617277000",
-          "Units": "NA",
-          "Legal": "BROOKWOOD HILLS BLK  2 LT   4  G:2733",
-          "Valuation": "13629",
-          "formatted_address": "2022 Brandilyn St, Anchorage, AK 99516, USA",
-          "lat": "61.11243819999999",
-          "lng": "-149.8435479"
-        }
+        "Permit": "R19-1191",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2022 BRANDILYN, Anchorage, Alaska",
+        "Parcel": "1617277000",
+        "Units": "NA",
+        "Legal": "BROOKWOOD HILLS BLK  2 LT   4  G:2733",
+        "Valuation": "13629",
+        "formatted_address": "2022 Brandilyn St, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -362,21 +310,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1221",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3906 BARBARA DRIVE, Anchorage, Alaska",
-          "Parcel": "1019412000",
-          "Units": "NA",
-          "Legal": "KIRCHNER LT  15  G:1727",
-          "Valuation": "14396",
-          "formatted_address": "3906 Barbara Dr, Anchorage, AK 99517, USA",
-          "lat": "61.18417779999999",
-          "lng": "-149.9330464"
-        }
+        "Permit": "R19-1221",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3906 BARBARA DRIVE, Anchorage, Alaska",
+        "Parcel": "1019412000",
+        "Units": "NA",
+        "Legal": "KIRCHNER LT  15  G:1727",
+        "Valuation": "14396",
+        "formatted_address": "3906 Barbara Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -389,21 +333,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1222",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1527 K, Anchorage, Alaska",
-          "Parcel": "109223000",
-          "Units": "NA",
-          "Legal": "MARTIN AND WELCH (SOUTH ADD) BLK 43B LT  17  G:1429",
-          "Valuation": "14396",
-          "formatted_address": "1527 K St, Anchorage, AK 99501, USA",
-          "lat": "61.20716100000001",
-          "lng": "-149.9012021"
-        }
+        "Permit": "R19-1222",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1527 K, Anchorage, Alaska",
+        "Parcel": "109223000",
+        "Units": "NA",
+        "Legal": "MARTIN AND WELCH (SOUTH ADD) BLK 43B LT  17  G:1429",
+        "Valuation": "14396",
+        "formatted_address": "1527 K St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -416,21 +356,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1294",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "4387 BLYTHE, Anchorage, Alaska",
-          "Parcel": "5075107000",
-          "Units": "NA",
-          "Legal": "TERI TR   A2  G:0704",
-          "Valuation": "10196",
-          "formatted_address": "4387 Blythe Way, Eagle River, AK 99577, USA",
-          "lat": "61.25971829999999",
-          "lng": "-149.2930479"
-        }
+        "Permit": "R19-1294",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "4387 BLYTHE, Anchorage, Alaska",
+        "Parcel": "5075107000",
+        "Units": "NA",
+        "Legal": "TERI TR   A2  G:0704",
+        "Valuation": "10196",
+        "formatted_address": "4387 Blythe Way, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -443,21 +379,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1317",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2213 FORAKER, Anchorage, Alaska",
-          "Parcel": "119104000",
-          "Units": "NA",
-          "Legal": "PARK BLK   P LT 18  G:1526",
-          "Valuation": "15000",
-          "formatted_address": "2213 Foraker Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1997145",
-          "lng": "-149.9462448"
-        }
+        "Permit": "R19-1317",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2213 FORAKER, Anchorage, Alaska",
+        "Parcel": "119104000",
+        "Units": "NA",
+        "Legal": "PARK BLK   P LT 18  G:1526",
+        "Valuation": "15000",
+        "formatted_address": "2213 Foraker Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -470,21 +402,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1318",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2910 JONES AVE, Anchorage, Alaska",
-          "Parcel": "1005106000",
-          "Units": "NA",
-          "Legal": "GLEN PARK ESTATES BLK  4 LT   4  G:1625",
-          "Valuation": "11000",
-          "formatted_address": "2910 Jones Ave, Anchorage, AK 99517, USA",
-          "lat": "61.194032",
-          "lng": "-149.9686408"
-        }
+        "Permit": "R19-1318",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2910 JONES AVE, Anchorage, Alaska",
+        "Parcel": "1005106000",
+        "Units": "NA",
+        "Legal": "GLEN PARK ESTATES BLK  4 LT   4  G:1625",
+        "Valuation": "11000",
+        "formatted_address": "2910 Jones Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -497,21 +425,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1329",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "4321 RENDEZVOUS, Anchorage, Alaska",
-          "Parcel": "723452000",
-          "Units": "NA",
-          "Legal": "CHUGACH FOOTHILLS #2 BLK  6 LT  25  G:1741",
-          "Valuation": "9682",
-          "formatted_address": "4321 Rendezvous Cir, Anchorage, AK 99504, USA",
-          "lat": "61.18263409999999",
-          "lng": "-149.7198881"
-        }
+        "Permit": "R19-1329",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "4321 RENDEZVOUS, Anchorage, Alaska",
+        "Parcel": "723452000",
+        "Units": "NA",
+        "Legal": "CHUGACH FOOTHILLS #2 BLK  6 LT  25  G:1741",
+        "Valuation": "9682",
+        "formatted_address": "4321 Rendezvous Cir, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -524,21 +448,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1330",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "15040 OLD SEWARD, Anchorage, Alaska",
-          "Parcel": "1829109000",
-          "Units": "NA",
-          "Legal": "CHENOWETH LT  3  G:3134",
-          "Valuation": "13990",
-          "formatted_address": "15040 Old Seward Hwy, Anchorage, AK 99516, USA",
-          "lat": "61.0846598",
-          "lng": "-149.8306189"
-        }
+        "Permit": "R19-1330",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "15040 OLD SEWARD, Anchorage, Alaska",
+        "Parcel": "1829109000",
+        "Units": "NA",
+        "Legal": "CHENOWETH LT  3  G:3134",
+        "Valuation": "13990",
+        "formatted_address": "15040 Old Seward Hwy, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -551,21 +471,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1332",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1335 I STREET, Anchorage, Alaska",
-          "Parcel": "109139000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 37A LT   8  G:1429",
-          "Valuation": "15765",
-          "formatted_address": "1335 I St, Anchorage, AK 99501, USA",
-          "lat": "61.20897120000001",
-          "lng": "-149.8991302"
-        }
+        "Permit": "R19-1332",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1335 I STREET, Anchorage, Alaska",
+        "Parcel": "109139000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 37A LT   8  G:1429",
+        "Valuation": "15765",
+        "formatted_address": "1335 I St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -578,21 +494,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1334",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1035 P, Anchorage, Alaska",
-          "Parcel": "108404000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 15A LT   8  G:1329",
-          "Valuation": "16727",
-          "formatted_address": "1035 P St, Anchorage, AK 99501, USA",
-          "lat": "61.2119332",
-          "lng": "-149.9113423"
-        }
+        "Permit": "R19-1334",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1035 P, Anchorage, Alaska",
+        "Parcel": "108404000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 15A LT   8  G:1329",
+        "Valuation": "16727",
+        "formatted_address": "1035 P St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -605,21 +517,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1354",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2901 ILLIAMNA, Anchorage, Alaska",
-          "Parcel": "118508000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HEIGHTS TR   C LT 38  G:1527",
-          "Valuation": "15000",
-          "formatted_address": "2901 Illiamna Ave, Anchorage, AK 99517, USA",
-          "lat": "61.2013255",
-          "lng": "-149.9416054"
-        }
+        "Permit": "R19-1354",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2901 ILLIAMNA, Anchorage, Alaska",
+        "Parcel": "118508000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HEIGHTS TR   C LT 38  G:1527",
+        "Valuation": "15000",
+        "formatted_address": "2901 Illiamna Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -632,21 +540,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1355",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2920 WILEY POST, Anchorage, Alaska",
-          "Parcel": "1013135000",
-          "Units": "NA",
-          "Legal": "BROADMOOR ESTATES #3 BLK  7 LT  37  G:1727",
-          "Valuation": "10000",
-          "formatted_address": "2920 Wiley Post Ave, Anchorage, AK 99517, USA",
-          "lat": "61.18714549999999",
-          "lng": "-149.9383895"
-        }
+        "Permit": "R19-1355",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2920 WILEY POST, Anchorage, Alaska",
+        "Parcel": "1013135000",
+        "Units": "NA",
+        "Legal": "BROADMOOR ESTATES #3 BLK  7 LT  37  G:1727",
+        "Valuation": "10000",
+        "formatted_address": "2920 Wiley Post Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -659,21 +563,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1356",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "4210 WORONZOF, Anchorage, Alaska",
-          "Parcel": "1005370000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN WEST BLK  2 LT  15  G:1625",
-          "Valuation": "14000",
-          "formatted_address": "4210 Woronzof Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19359840000001",
-          "lng": "-149.9637762"
-        }
+        "Permit": "R19-1356",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "4210 WORONZOF, Anchorage, Alaska",
+        "Parcel": "1005370000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN WEST BLK  2 LT  15  G:1625",
+        "Valuation": "14000",
+        "formatted_address": "4210 Woronzof Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -686,21 +586,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1368",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2808 DILIGENCE CIRCLE, Anchorage, Alaska",
-          "Parcel": "1912255000",
-          "Units": "NA",
-          "Legal": "DISCOVERY LT 17A  G:2727",
-          "Valuation": "46665",
-          "formatted_address": "2808 Diligence Cir, Anchorage, AK 99515, USA",
-          "lat": "61.11384229999999",
-          "lng": "-149.932183"
-        }
+        "Permit": "R19-1368",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2808 DILIGENCE CIRCLE, Anchorage, Alaska",
+        "Parcel": "1912255000",
+        "Units": "NA",
+        "Legal": "DISCOVERY LT 17A  G:2727",
+        "Valuation": "46665",
+        "formatted_address": "2808 Diligence Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -713,21 +609,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1397",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "E 359 24TH, Anchorage, Alaska",
-          "Parcel": "220326000",
-          "Units": "NA",
-          "Legal": "PEARL V SMITH BLK  2 LT   3A  G:1531",
-          "Valuation": "21240",
-          "formatted_address": "359 E 24th Ave, Anchorage, AK 99503, USA",
-          "lat": "61.19935390000001",
-          "lng": "-149.8769253"
-        }
+        "Permit": "R19-1397",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "E 359 24TH, Anchorage, Alaska",
+        "Parcel": "220326000",
+        "Units": "NA",
+        "Legal": "PEARL V SMITH BLK  2 LT   3A  G:1531",
+        "Valuation": "21240",
+        "formatted_address": "359 E 24th Ave, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -740,21 +632,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1398",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "E 225 11TH, Anchorage, Alaska",
-          "Parcel": "213644000",
-          "Units": "NA",
-          "Legal": "THIRD ADDITION BLK 13 LT  11  G:1331",
-          "Valuation": "15666",
-          "formatted_address": "225 W 11th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.211883",
-          "lng": "-149.8867466"
-        }
+        "Permit": "R19-1398",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "E 225 11TH, Anchorage, Alaska",
+        "Parcel": "213644000",
+        "Units": "NA",
+        "Legal": "THIRD ADDITION BLK 13 LT  11  G:1331",
+        "Valuation": "15666",
+        "formatted_address": "225 W 11th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -767,21 +655,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1399",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "7240 STAMPS CIRCLE, Anchorage, Alaska",
-          "Parcel": "1506252000",
-          "Units": "NA",
-          "Legal": "SILVER CREST BLK  2 LT  21  G:2439",
-          "Valuation": "20800",
-          "formatted_address": "7240 Stamps Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1342595",
-          "lng": "-149.7461574"
-        }
+        "Permit": "R19-1399",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "7240 STAMPS CIRCLE, Anchorage, Alaska",
+        "Parcel": "1506252000",
+        "Units": "NA",
+        "Legal": "SILVER CREST BLK  2 LT  21  G:2439",
+        "Valuation": "20800",
+        "formatted_address": "7240 Stamps Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -794,21 +678,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1400",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1737 SCENIC, Anchorage, Alaska",
-          "Parcel": "110250000",
-          "Units": "NA",
-          "Legal": "SCHODDE (SOUTH ADD) BLK 32 LT  10  G:1428",
-          "Valuation": "16164",
-          "formatted_address": "1737 Scenic Way, Anchorage, AK 99501, USA",
-          "lat": "61.20897069999999",
-          "lng": "-149.9172508"
-        }
+        "Permit": "R19-1400",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1737 SCENIC, Anchorage, Alaska",
+        "Parcel": "110250000",
+        "Units": "NA",
+        "Legal": "SCHODDE (SOUTH ADD) BLK 32 LT  10  G:1428",
+        "Valuation": "16164",
+        "formatted_address": "1737 Scenic Way, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -821,21 +701,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1419",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "10005 GOODNEWS, Anchorage, Alaska",
-          "Parcel": "1247130000",
-          "Units": "NA",
-          "Legal": "BAYSHORE WEST #1 BLK  1 LT   9  G:2526",
-          "Valuation": "26598",
-          "formatted_address": "10005 Goodnews Cir, Anchorage, AK 99515, USA",
-          "lat": "61.12983000000001",
-          "lng": "-149.9415714"
-        }
+        "Permit": "R19-1419",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "10005 GOODNEWS, Anchorage, Alaska",
+        "Parcel": "1247130000",
+        "Units": "NA",
+        "Legal": "BAYSHORE WEST #1 BLK  1 LT   9  G:2526",
+        "Valuation": "26598",
+        "formatted_address": "10005 Goodnews Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -848,21 +724,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1420",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1307 13TH, Anchorage, Alaska",
-          "Parcel": "108497000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 26C LTS 11 & 12 G:1329",
-          "Valuation": "16444",
-          "formatted_address": "1307 W 13th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2099501",
-          "lng": "-149.908216"
-        }
+        "Permit": "R19-1420",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1307 13TH, Anchorage, Alaska",
+        "Parcel": "108497000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 26C LTS 11 & 12 G:1329",
+        "Valuation": "16444",
+        "formatted_address": "1307 W 13th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -875,21 +747,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1442",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3000 MCCOLLIE AVE, Anchorage, Alaska",
-          "Parcel": "118514000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HEIGHTS TR  C LT   6  G:1527",
-          "Valuation": "15000",
-          "formatted_address": "3000 Mccollie Ave, Anchorage, AK 99517, USA",
-          "lat": "61.2018026",
-          "lng": "-149.9422704"
-        }
+        "Permit": "R19-1442",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3000 MCCOLLIE AVE, Anchorage, Alaska",
+        "Parcel": "118514000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HEIGHTS TR  C LT   6  G:1527",
+        "Valuation": "15000",
+        "formatted_address": "3000 Mccollie Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -902,21 +770,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1443",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2908 LEIGHTON STREET, Anchorage, Alaska",
-          "Parcel": "1004464000",
-          "Units": "NA",
-          "Legal": "WAGNER ESTATES #3 BLK  9 LT  12  G:1626",
-          "Valuation": "10000",
-          "formatted_address": "2908 Leighton St, Anchorage, AK 99517, USA",
-          "lat": "61.193895500000004",
-          "lng": "-149.9544768"
-        }
+        "Permit": "R19-1443",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2908 LEIGHTON STREET, Anchorage, Alaska",
+        "Parcel": "1004464000",
+        "Units": "NA",
+        "Legal": "WAGNER ESTATES #3 BLK  9 LT  12  G:1626",
+        "Valuation": "10000",
+        "formatted_address": "2908 Leighton St, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -929,21 +793,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1444",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2917 JONES AVE, Anchorage, Alaska",
-          "Parcel": "1005127000",
-          "Units": "NA",
-          "Legal": "GLEN PARK ESTATES BLK  1 LT   7  G:1625",
-          "Valuation": "18000",
-          "formatted_address": "2917 Jones Ave, Anchorage, AK 99517, USA",
-          "lat": "61.1935482",
-          "lng": "-149.9684082"
-        }
+        "Permit": "R19-1444",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2917 JONES AVE, Anchorage, Alaska",
+        "Parcel": "1005127000",
+        "Units": "NA",
+        "Legal": "GLEN PARK ESTATES BLK  1 LT   7  G:1625",
+        "Valuation": "18000",
+        "formatted_address": "2917 Jones Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -956,21 +816,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1446",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2858 KNIK, Anchorage, Alaska",
-          "Parcel": "123423000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HOMES BLK  I LT   5  G:1527",
-          "Valuation": "10000",
-          "formatted_address": "2858 Knik Ave, Anchorage, AK 99517, USA",
-          "lat": "61.19601849999999",
-          "lng": "-149.9388457"
-        }
+        "Permit": "R19-1446",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2858 KNIK, Anchorage, Alaska",
+        "Parcel": "123423000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HOMES BLK  I LT   5  G:1527",
+        "Valuation": "10000",
+        "formatted_address": "2858 Knik Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -983,21 +839,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1447",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3023 KNIK, Anchorage, Alaska",
-          "Parcel": "123631000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HOMES BLK  H LT  19  G:1527",
-          "Valuation": "18000",
-          "formatted_address": "3023 Knik Ave, Anchorage, AK 99517, USA",
-          "lat": "61.1964551",
-          "lng": "-149.9422814"
-        }
+        "Permit": "R19-1447",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3023 KNIK, Anchorage, Alaska",
+        "Parcel": "123631000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HOMES BLK  H LT  19  G:1527",
+        "Valuation": "18000",
+        "formatted_address": "3023 Knik Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1010,21 +862,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1456",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2200 MCKENZIE DRIVE, Anchorage, Alaska",
-          "Parcel": "119432000",
-          "Units": "NA",
-          "Legal": "SIMONSON ESTATES BLK  A LT   1B  G:1526",
-          "Valuation": "12000",
-          "formatted_address": "2200 Mckenzie Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1995003",
-          "lng": "-149.9508311"
-        }
+        "Permit": "R19-1456",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2200 MCKENZIE DRIVE, Anchorage, Alaska",
+        "Parcel": "119432000",
+        "Units": "NA",
+        "Legal": "SIMONSON ESTATES BLK  A LT   1B  G:1526",
+        "Valuation": "12000",
+        "formatted_address": "2200 Mckenzie Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1037,21 +885,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1458",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2850 PRIBILOF, Anchorage, Alaska",
-          "Parcel": "1005341000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN WEST BLK  1 LT  37  G:1625",
-          "Valuation": "8000",
-          "formatted_address": "2850 Pribilof St, Anchorage, AK 99517, USA",
-          "lat": "61.19425680000001",
-          "lng": "-149.9592556"
-        }
+        "Permit": "R19-1458",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2850 PRIBILOF, Anchorage, Alaska",
+        "Parcel": "1005341000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN WEST BLK  1 LT  37  G:1625",
+        "Valuation": "8000",
+        "formatted_address": "2850 Pribilof St, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1064,21 +908,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1462",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2340 CAPTAIN COOK, Anchorage, Alaska",
-          "Parcel": "118408000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HOMES BLK  F LT  16  G:1527",
-          "Valuation": "18000",
-          "formatted_address": "2340 Captain Cook Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19947449999999",
-          "lng": "-149.9404185"
-        }
+        "Permit": "R19-1462",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2340 CAPTAIN COOK, Anchorage, Alaska",
+        "Parcel": "118408000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HOMES BLK  F LT  16  G:1527",
+        "Valuation": "18000",
+        "formatted_address": "2340 Captain Cook Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1091,21 +931,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1465",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1401 13TH, Anchorage, Alaska",
-          "Parcel": "108474000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 26D LT  11A  G:1329",
-          "Valuation": "15321",
-          "formatted_address": "1401 W 13th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.20998770000001",
-          "lng": "-149.9099171"
-        }
+        "Permit": "R19-1465",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1401 13TH, Anchorage, Alaska",
+        "Parcel": "108474000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 26D LT  11A  G:1329",
+        "Valuation": "15321",
+        "formatted_address": "1401 W 13th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -1118,21 +954,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1466",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "941 DAVID PLACE, Anchorage, Alaska",
-          "Parcel": "107230000",
-          "Units": "NA",
-          "Legal": "L STREET SLIDE REPLAT PHASE 2 BLK 13 LT   4A  G:1328",
-          "Valuation": "8762",
-          "formatted_address": "941 David Pl, Anchorage, AK 99501, USA",
-          "lat": "61.2128131",
-          "lng": "-149.9146342"
-        }
+        "Permit": "R19-1466",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "941 DAVID PLACE, Anchorage, Alaska",
+        "Parcel": "107230000",
+        "Units": "NA",
+        "Legal": "L STREET SLIDE REPLAT PHASE 2 BLK 13 LT   4A  G:1328",
+        "Valuation": "8762",
+        "formatted_address": "941 David Pl, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -1145,21 +977,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1467",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "4220 GALACTICA, Anchorage, Alaska",
-          "Parcel": "1006144000",
-          "Units": "NA",
-          "Legal": "SATELLITE PARK BLK  3 LT   3  G:1625",
-          "Valuation": "12000",
-          "formatted_address": "4220 Galactica Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19131460000001",
-          "lng": "-149.9647324"
-        }
+        "Permit": "R19-1467",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "4220 GALACTICA, Anchorage, Alaska",
+        "Parcel": "1006144000",
+        "Units": "NA",
+        "Legal": "SATELLITE PARK BLK  3 LT   3  G:1625",
+        "Valuation": "12000",
+        "formatted_address": "4220 Galactica Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1172,21 +1000,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1470",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2316 SUSITNA, Anchorage, Alaska",
-          "Parcel": "119220000",
-          "Units": "NA",
-          "Legal": "PARK BLK   R LT  11  G:1526",
-          "Valuation": "10000",
-          "formatted_address": "2316 Susitna Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1989894",
-          "lng": "-149.9489453"
-        }
+        "Permit": "R19-1470",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2316 SUSITNA, Anchorage, Alaska",
+        "Parcel": "119220000",
+        "Units": "NA",
+        "Legal": "PARK BLK   R LT  11  G:1526",
+        "Valuation": "10000",
+        "formatted_address": "2316 Susitna Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1199,21 +1023,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1471",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2521 SAINT ELIAS, Anchorage, Alaska",
-          "Parcel": "123616000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HOMES BLK  G LT  12  G:1527",
-          "Valuation": "10000",
-          "formatted_address": "2521 St Elias Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1975492",
-          "lng": "-149.9409887"
-        }
+        "Permit": "R19-1471",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2521 SAINT ELIAS, Anchorage, Alaska",
+        "Parcel": "123616000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HOMES BLK  G LT  12  G:1527",
+        "Valuation": "10000",
+        "formatted_address": "2521 St Elias Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1226,21 +1046,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1472",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2336 FOREST PARK, Anchorage, Alaska",
-          "Parcel": "118108000",
-          "Units": "NA",
-          "Legal": "FOREST HIGHLANDS LT   3  G:1527",
-          "Valuation": "14000",
-          "formatted_address": "2336 Forest Park Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1990877",
-          "lng": "-149.9285331"
-        }
+        "Permit": "R19-1472",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2336 FOREST PARK, Anchorage, Alaska",
+        "Parcel": "118108000",
+        "Units": "NA",
+        "Legal": "FOREST HIGHLANDS LT   3  G:1527",
+        "Valuation": "14000",
+        "formatted_address": "2336 Forest Park Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1253,21 +1069,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1473",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2247 ARCTIC, Anchorage, Alaska",
-          "Parcel": "118206000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HEIGHTS BLK   B LT 12  G:1527",
-          "Valuation": "19000",
-          "formatted_address": "2247 Arctic Blvd, Anchorage, AK 99503, USA",
-          "lat": "61.2001838",
-          "lng": "-149.8966842"
-        }
+        "Permit": "R19-1473",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2247 ARCTIC, Anchorage, Alaska",
+        "Parcel": "118206000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HEIGHTS BLK   B LT 12  G:1527",
+        "Valuation": "19000",
+        "formatted_address": "2247 Arctic Blvd, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -1280,21 +1092,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1513",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2401 FORAKER, Anchorage, Alaska",
-          "Parcel": "122244000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HOMES BLK  P LT  22  G:1526",
-          "Valuation": "18000",
-          "formatted_address": "2401 Foraker Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19881779999999",
-          "lng": "-149.9463875"
-        }
+        "Permit": "R19-1513",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2401 FORAKER, Anchorage, Alaska",
+        "Parcel": "122244000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HOMES BLK  P LT  22  G:1526",
+        "Valuation": "18000",
+        "formatted_address": "2401 Foraker Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1307,21 +1115,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1514",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "4200 WORONZOF, Anchorage, Alaska",
-          "Parcel": "1005369000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN WEST BLK  2 LT  16  G:1625",
-          "Valuation": "19000",
-          "formatted_address": "4200 Woronzof Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19357939999999",
-          "lng": "-149.9634921"
-        }
+        "Permit": "R19-1514",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "4200 WORONZOF, Anchorage, Alaska",
+        "Parcel": "1005369000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN WEST BLK  2 LT  16  G:1625",
+        "Valuation": "19000",
+        "formatted_address": "4200 Woronzof Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1334,21 +1138,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1515",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 2219 MARSTON, Anchorage, Alaska",
-          "Parcel": "119425000",
-          "Units": "NA",
-          "Legal": "SIMONSON ESTATES BLK  B LT  10  G:1526",
-          "Valuation": "15000",
-          "formatted_address": "2219 Marston Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1996738",
-          "lng": "-149.953528"
-        }
+        "Permit": "R19-1515",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 2219 MARSTON, Anchorage, Alaska",
+        "Parcel": "119425000",
+        "Units": "NA",
+        "Legal": "SIMONSON ESTATES BLK  B LT  10  G:1526",
+        "Valuation": "15000",
+        "formatted_address": "2219 Marston Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1361,21 +1161,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1516",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3003 CARROLL, Anchorage, Alaska",
-          "Parcel": "1019120000",
-          "Units": "NA",
-          "Legal": "BROADMOOR ESTATES BLK  3 LT   2  G:1727",
-          "Valuation": "15000",
-          "formatted_address": "3003 Carroll Ln, Anchorage, AK 99517, USA",
-          "lat": "61.1839367",
-          "lng": "-149.9388576"
-        }
+        "Permit": "R19-1516",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3003 CARROLL, Anchorage, Alaska",
+        "Parcel": "1019120000",
+        "Units": "NA",
+        "Legal": "BROADMOOR ESTATES BLK  3 LT   2  G:1727",
+        "Valuation": "15000",
+        "formatted_address": "3003 Carroll Ln, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1388,21 +1184,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1518",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 3936 37TH, Anchorage, Alaska",
-          "Parcel": "1014414000",
-          "Units": "NA",
-          "Legal": "BROADMOOR ESTATES WEST #1 BLK  3 LT   5  G:1726",
-          "Valuation": "18000",
-          "formatted_address": "3936 W 37th Ct, Anchorage, AK 99517, USA",
-          "lat": "61.1873921",
-          "lng": "-149.955241"
-        }
+        "Permit": "R19-1518",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 3936 37TH, Anchorage, Alaska",
+        "Parcel": "1014414000",
+        "Units": "NA",
+        "Legal": "BROADMOOR ESTATES WEST #1 BLK  3 LT   5  G:1726",
+        "Valuation": "18000",
+        "formatted_address": "3936 W 37th Ct, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1415,21 +1207,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1519",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2527 SUSITNA, Anchorage, Alaska",
-          "Parcel": "122315000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HOMES BLK  Q LT  25  G:1526",
-          "Valuation": "9000",
-          "formatted_address": "2527 Susitna Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19763889999999",
-          "lng": "-149.9480548"
-        }
+        "Permit": "R19-1519",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2527 SUSITNA, Anchorage, Alaska",
+        "Parcel": "122315000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HOMES BLK  Q LT  25  G:1526",
+        "Valuation": "9000",
+        "formatted_address": "2527 Susitna Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1442,21 +1230,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1520",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3232 KNIK, Anchorage, Alaska",
-          "Parcel": "122133000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HOMES BLK  O LT   7  G:1526",
-          "Valuation": "19000",
-          "formatted_address": "3232 Knik Ave, Anchorage, AK 99517, USA",
-          "lat": "61.19628780000001",
-          "lng": "-149.946131"
-        }
+        "Permit": "R19-1520",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3232 KNIK, Anchorage, Alaska",
+        "Parcel": "122133000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HOMES BLK  O LT   7  G:1526",
+        "Valuation": "19000",
+        "formatted_address": "3232 Knik Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1469,21 +1253,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1521",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 3100 29TH, Anchorage, Alaska",
-          "Parcel": "1003124000",
-          "Units": "NA",
-          "Legal": "MCRAE (SUBD OF LT 11) LT   3 (OF LT  11)  G:1627",
-          "Valuation": "9000",
-          "formatted_address": "3100 W 29th Ave, Anchorage, AK 99517, USA",
-          "lat": "61.1942078",
-          "lng": "-149.9411208"
-        }
+        "Permit": "R19-1521",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 3100 29TH, Anchorage, Alaska",
+        "Parcel": "1003124000",
+        "Units": "NA",
+        "Legal": "MCRAE (SUBD OF LT 11) LT   3 (OF LT  11)  G:1627",
+        "Valuation": "9000",
+        "formatted_address": "3100 W 29th Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1496,21 +1276,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1522",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3417 AERO, Anchorage, Alaska",
-          "Parcel": "1007208000",
-          "Units": "NA",
-          "Legal": "HAWTHORNE BLK  2 LT   8  G:1626",
-          "Valuation": "10000",
-          "formatted_address": "3417 Aero Ave, Anchorage, AK 99517, USA",
-          "lat": "61.1894797",
-          "lng": "-149.9574234"
-        }
+        "Permit": "R19-1522",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3417 AERO, Anchorage, Alaska",
+        "Parcel": "1007208000",
+        "Units": "NA",
+        "Legal": "HAWTHORNE BLK  2 LT   8  G:1626",
+        "Valuation": "10000",
+        "formatted_address": "3417 Aero Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1523,21 +1299,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1523",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "6400 NORM, Anchorage, Alaska",
-          "Parcel": "1406265000",
-          "Units": "NA",
-          "Legal": "CARRIAGE ESTATES PHASE 1 BLK  2 LT  36  G:2034",
-          "Valuation": "26000",
-          "formatted_address": "6400 Norm Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1627493",
-          "lng": "-149.823178"
-        }
+        "Permit": "R19-1523",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "6400 NORM, Anchorage, Alaska",
+        "Parcel": "1406265000",
+        "Units": "NA",
+        "Legal": "CARRIAGE ESTATES PHASE 1 BLK  2 LT  36  G:2034",
+        "Valuation": "26000",
+        "formatted_address": "6400 Norm Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -1550,21 +1322,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1524",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3329 STARLITE, Anchorage, Alaska",
-          "Parcel": "1006165000",
-          "Units": "NA",
-          "Legal": "SATELLITE PARK BLK   2 LT 22  G:1625",
-          "Valuation": "10000",
-          "formatted_address": "3329 Starlite Cir, Anchorage, AK 99517, USA",
-          "lat": "61.19004880000001",
-          "lng": "-149.9626405"
-        }
+        "Permit": "R19-1524",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3329 STARLITE, Anchorage, Alaska",
+        "Parcel": "1006165000",
+        "Units": "NA",
+        "Legal": "SATELLITE PARK BLK   2 LT 22  G:1625",
+        "Valuation": "10000",
+        "formatted_address": "3329 Starlite Cir, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1577,21 +1345,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1525",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "140 BREE, Anchorage, Alaska",
-          "Parcel": "1804109000",
-          "Units": "NA",
-          "Legal": "OCEANVIEW ESTATES BLK  1 LT   5  G:2830",
-          "Valuation": "15000",
-          "formatted_address": "140 Bree Ave, Anchorage, AK 99515, USA",
-          "lat": "61.10513309999999",
-          "lng": "-149.8812558"
-        }
+        "Permit": "R19-1525",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "140 BREE, Anchorage, Alaska",
+        "Parcel": "1804109000",
+        "Units": "NA",
+        "Legal": "OCEANVIEW ESTATES BLK  1 LT   5  G:2830",
+        "Valuation": "15000",
+        "formatted_address": "140 Bree Ave, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -1604,21 +1368,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1526",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "4150 HORIZON AVENUE, Anchorage, Alaska",
-          "Parcel": "1005220000",
-          "Units": "NA",
-          "Legal": "WORONZOF WEST #2 BLK  2 LT  15A  G:1625",
-          "Valuation": "9000",
-          "formatted_address": "4150 Horizon Ave, Anchorage, AK 99517, USA",
-          "lat": "61.1919176",
-          "lng": "-149.9624593"
-        }
+        "Permit": "R19-1526",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "4150 HORIZON AVENUE, Anchorage, Alaska",
+        "Parcel": "1005220000",
+        "Units": "NA",
+        "Legal": "WORONZOF WEST #2 BLK  2 LT  15A  G:1625",
+        "Valuation": "9000",
+        "formatted_address": "4150 Horizon Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -1631,21 +1391,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1527",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1327 P STREET, Anchorage, Alaska",
-          "Parcel": "109635000",
-          "Units": "NA",
-          "Legal": "VIEW RIDGE (OF SOUTH ADDN) BLK 34A LT  23  G:1429",
-          "Valuation": "12800",
-          "formatted_address": "1327 P St, Anchorage, AK 99501, USA",
-          "lat": "61.209135",
-          "lng": "-149.9113311"
-        }
+        "Permit": "R19-1527",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1327 P STREET, Anchorage, Alaska",
+        "Parcel": "109635000",
+        "Units": "NA",
+        "Legal": "VIEW RIDGE (OF SOUTH ADDN) BLK 34A LT  23  G:1429",
+        "Valuation": "12800",
+        "formatted_address": "1327 P St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -1658,21 +1414,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1546",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "13265 BADGER LANE, Anchorage, Alaska",
-          "Parcel": "1734310000",
-          "Units": "NA",
-          "Legal": "SECLUDED HILLS BLK  2 LT   2  G:2937",
-          "Valuation": "14990",
-          "formatted_address": "13265 Badger Ln, Anchorage, AK 99516, USA",
-          "lat": "61.1010017",
-          "lng": "-149.7798839"
-        }
+        "Permit": "R19-1546",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "13265 BADGER LANE, Anchorage, Alaska",
+        "Parcel": "1734310000",
+        "Units": "NA",
+        "Legal": "SECLUDED HILLS BLK  2 LT   2  G:2937",
+        "Valuation": "14990",
+        "formatted_address": "13265 Badger Ln, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -1685,21 +1437,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1547",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "13720 JARVI, Anchorage, Alaska",
-          "Parcel": "1815197000",
-          "Units": "NA",
-          "Legal": "SUNSET MANOR #2 BLK   6 LT   6A  G:2932",
-          "Valuation": "34505",
-          "formatted_address": "13720 Jarvi Dr, Anchorage, AK 99515, USA",
-          "lat": "61.0955627",
-          "lng": "-149.8547949"
-        }
+        "Permit": "R19-1547",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "13720 JARVI, Anchorage, Alaska",
+        "Parcel": "1815197000",
+        "Units": "NA",
+        "Legal": "SUNSET MANOR #2 BLK   6 LT   6A  G:2932",
+        "Valuation": "34505",
+        "formatted_address": "13720 Jarvi Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -1712,21 +1460,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1556",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 816 16TH, Anchorage, Alaska",
-          "Parcel": "115425000",
-          "Units": "NA",
-          "Legal": "CHESTER BLK  4 LT   3  G:1429",
-          "Valuation": "20886",
-          "formatted_address": "816 W 16th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2058647",
-          "lng": "-149.8986795"
-        }
+        "Permit": "R19-1556",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 816 16TH, Anchorage, Alaska",
+        "Parcel": "115425000",
+        "Units": "NA",
+        "Legal": "CHESTER BLK  4 LT   3  G:1429",
+        "Valuation": "20886",
+        "formatted_address": "816 W 16th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -1739,21 +1483,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1587",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1334 G, Anchorage, Alaska",
-          "Parcel": "215605000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 37B LT   5  G:1430",
-          "Valuation": "11320",
-          "formatted_address": "1334 G St, Anchorage, AK 99501, USA",
-          "lat": "61.20898669999999",
-          "lng": "-149.8961056"
-        }
+        "Permit": "R19-1587",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1334 G, Anchorage, Alaska",
+        "Parcel": "215605000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 37B LT   5  G:1430",
+        "Valuation": "11320",
+        "formatted_address": "1334 G St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -1766,21 +1506,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1588",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1522 COFFEY LANE, Anchorage, Alaska",
-          "Parcel": "109464000",
-          "Units": "NA",
-          "Legal": "COFFEY BLK 44C LT  3A  G:1429",
-          "Valuation": "18054",
-          "formatted_address": "1522 Coffey Ln, Anchorage, AK 99501, USA",
-          "lat": "61.20707569999999",
-          "lng": "-149.9046169"
-        }
+        "Permit": "R19-1588",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1522 COFFEY LANE, Anchorage, Alaska",
+        "Parcel": "109464000",
+        "Units": "NA",
+        "Legal": "COFFEY BLK 44C LT  3A  G:1429",
+        "Valuation": "18054",
+        "formatted_address": "1522 Coffey Ln, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -1793,21 +1529,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1661",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1451 13TH, Anchorage, Alaska",
-          "Parcel": "108479000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 26D LT   7A  G:1329",
-          "Valuation": "12597",
-          "formatted_address": "1451 W 13th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.20985229999999",
-          "lng": "-149.9116665"
-        }
+        "Permit": "R19-1661",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1451 13TH, Anchorage, Alaska",
+        "Parcel": "108479000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 26D LT   7A  G:1329",
+        "Valuation": "12597",
+        "formatted_address": "1451 W 13th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -1820,21 +1552,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1662",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1312 15TH, Anchorage, Alaska",
-          "Parcel": "109521000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 45 LT   2  G:1429",
-          "Valuation": "17315",
-          "formatted_address": "1312 E 15th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.20739200000001",
-          "lng": "-149.8585126"
-        }
+        "Permit": "R19-1662",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1312 15TH, Anchorage, Alaska",
+        "Parcel": "109521000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 45 LT   2  G:1429",
+        "Valuation": "17315",
+        "formatted_address": "1312 E 15th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -1847,21 +1575,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1663",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2627 LOVEJOY, Anchorage, Alaska",
-          "Parcel": "416220000",
-          "Units": "NA",
-          "Legal": "ANCHOR PARK BLK  1 LT  22  G:1534",
-          "Valuation": "7357",
-          "formatted_address": "Lovejoy Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1961472",
-          "lng": "-149.8343351"
-        }
+        "Permit": "R19-1663",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2627 LOVEJOY, Anchorage, Alaska",
+        "Parcel": "416220000",
+        "Units": "NA",
+        "Legal": "ANCHOR PARK BLK  1 LT  22  G:1534",
+        "Valuation": "7357",
+        "formatted_address": "Lovejoy Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -1874,21 +1598,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1687",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "10650 LONE TREE, Anchorage, Alaska",
-          "Parcel": "1532255000",
-          "Units": "NA",
-          "Legal": "VALLI VUE ESTATES #2 BLK  2 LT   3  G:2538",
-          "Valuation": "12493",
-          "formatted_address": "10650 Lone Tree Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1237858",
-          "lng": "-149.7609118"
-        }
+        "Permit": "R19-1687",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "10650 LONE TREE, Anchorage, Alaska",
+        "Parcel": "1532255000",
+        "Units": "NA",
+        "Legal": "VALLI VUE ESTATES #2 BLK  2 LT   3  G:2538",
+        "Valuation": "12493",
+        "formatted_address": "10650 Lone Tree Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -1901,21 +1621,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1709",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "6747 DOUBLE TREE, Anchorage, Alaska",
-          "Parcel": "1531109000",
-          "Units": "NA",
-          "Legal": "VALLI VUE ESTATES #1 BLK  1 LT   8  G:2539",
-          "Valuation": "33070",
-          "formatted_address": "6747 Double Tree Ct, Anchorage, AK 99507, USA",
-          "lat": "61.1244737",
-          "lng": "-149.7565473"
-        }
+        "Permit": "R19-1709",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "6747 DOUBLE TREE, Anchorage, Alaska",
+        "Parcel": "1531109000",
+        "Units": "NA",
+        "Legal": "VALLI VUE ESTATES #1 BLK  1 LT   8  G:2539",
+        "Valuation": "33070",
+        "formatted_address": "6747 Double Tree Ct, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -1928,21 +1644,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1710",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "5323 KEUKA, Anchorage, Alaska",
-          "Parcel": "512208000",
-          "Units": "NA",
-          "Legal": "COLLEGEGATE #6 BLK 11 LT  29  G:1637",
-          "Valuation": "11900",
-          "formatted_address": "5323 Keuka Ct, Anchorage, AK 99508, USA",
-          "lat": "61.1909413",
-          "lng": "-149.7824902"
-        }
+        "Permit": "R19-1710",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "5323 KEUKA, Anchorage, Alaska",
+        "Parcel": "512208000",
+        "Units": "NA",
+        "Legal": "COLLEGEGATE #6 BLK 11 LT  29  G:1637",
+        "Valuation": "11900",
+        "formatted_address": "5323 Keuka Ct, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -1955,21 +1667,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1814",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1134 H, Anchorage, Alaska",
-          "Parcel": "108113000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 23A LT   4A  G:1329",
-          "Valuation": "16727",
-          "formatted_address": "1134 H St, Anchorage, AK 99501, USA",
-          "lat": "61.210976",
-          "lng": "-149.8980078"
-        }
+        "Permit": "R19-1814",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1134 H, Anchorage, Alaska",
+        "Parcel": "108113000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 23A LT   4A  G:1329",
+        "Valuation": "16727",
+        "formatted_address": "1134 H St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -1982,21 +1690,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1815",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1130 S, Anchorage, Alaska",
-          "Parcel": "107308000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 28 LT  10 N 75' OF S1/2  G:1328",
-          "Valuation": "14693",
-          "formatted_address": "1130 S St, Anchorage, AK 99501, USA",
-          "lat": "61.21104690000001",
-          "lng": "-149.916472"
-        }
+        "Permit": "R19-1815",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1130 S, Anchorage, Alaska",
+        "Parcel": "107308000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 28 LT  10 N 75' OF S1/2  G:1328",
+        "Valuation": "14693",
+        "formatted_address": "1130 S St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2009,21 +1713,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1816",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1651 SUNRISE, Anchorage, Alaska",
-          "Parcel": "414117000",
-          "Units": "NA",
-          "Legal": "SAXTON BLK  8 LT   4  G:1434",
-          "Valuation": "17936",
-          "formatted_address": "1651 Sunrise Dr, Anchorage, AK 99508, USA",
-          "lat": "61.20521909999999",
-          "lng": "-149.823987"
-        }
+        "Permit": "R19-1816",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1651 SUNRISE, Anchorage, Alaska",
+        "Parcel": "414117000",
+        "Units": "NA",
+        "Legal": "SAXTON BLK  8 LT   4  G:1434",
+        "Valuation": "17936",
+        "formatted_address": "1651 Sunrise Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -2036,21 +1736,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1817",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2303 MC RAE, Anchorage, Alaska",
-          "Parcel": "1012317000",
-          "Units": "NA",
-          "Legal": "LINTNER LT 37  G:1728",
-          "Valuation": "21949",
-          "formatted_address": "2303 McRae Rd, Anchorage, AK 99517, USA",
-          "lat": "61.18604019999999",
-          "lng": "-149.9252181"
-        }
+        "Permit": "R19-1817",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2303 MC RAE, Anchorage, Alaska",
+        "Parcel": "1012317000",
+        "Units": "NA",
+        "Legal": "LINTNER LT 37  G:1728",
+        "Valuation": "21949",
+        "formatted_address": "2303 McRae Rd, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -2063,21 +1759,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1818",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1515 15TH, Anchorage, Alaska",
-          "Parcel": "110239000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 33D LT   9  G:1428",
-          "Valuation": "15665",
-          "formatted_address": "1515 E 15th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2077532",
-          "lng": "-149.8544223"
-        }
+        "Permit": "R19-1818",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1515 15TH, Anchorage, Alaska",
+        "Parcel": "110239000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 33D LT   9  G:1428",
+        "Valuation": "15665",
+        "formatted_address": "1515 E 15th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2090,21 +1782,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1819",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1555 E, Anchorage, Alaska",
-          "Parcel": "215352000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 40A LT  18A  G:1430",
-          "Valuation": "15075",
-          "formatted_address": "1555 E St, Anchorage, AK 99501, USA",
-          "lat": "61.2065642",
-          "lng": "-149.8909413"
-        }
+        "Permit": "R19-1819",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1555 E, Anchorage, Alaska",
+        "Parcel": "215352000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 40A LT  18A  G:1430",
+        "Valuation": "15075",
+        "formatted_address": "1555 E St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2117,21 +1805,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1845",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1301 HEIDI, Anchorage, Alaska",
-          "Parcel": "1211307000",
-          "Units": "NA",
-          "Legal": "NOMEN BLK  1 LT   7  G:2129",
-          "Valuation": "20637",
-          "formatted_address": "1301 Heidi Cir, Anchorage, AK 99518, USA",
-          "lat": "61.1581606",
-          "lng": "-149.9036834"
-        }
+        "Permit": "R19-1845",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1301 HEIDI, Anchorage, Alaska",
+        "Parcel": "1211307000",
+        "Units": "NA",
+        "Legal": "NOMEN BLK  1 LT   7  G:2129",
+        "Valuation": "20637",
+        "formatted_address": "1301 Heidi Cir, Anchorage, AK 99518, USA"
       }
     },
     {
@@ -2144,21 +1828,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1883",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "940 P STREET, Anchorage, Alaska",
-          "Parcel": "107242000",
-          "Units": "NA",
-          "Legal": "L STREET SLIDE REPLAT BLK 13A LT   7D  G:1328",
-          "Valuation": "16396",
-          "formatted_address": "940 P St, Anchorage, AK 99501, USA",
-          "lat": "61.2128556",
-          "lng": "-149.9125395"
-        }
+        "Permit": "R19-1883",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "940 P STREET, Anchorage, Alaska",
+        "Parcel": "107242000",
+        "Units": "NA",
+        "Legal": "L STREET SLIDE REPLAT BLK 13A LT   7D  G:1328",
+        "Valuation": "16396",
+        "formatted_address": "940 P St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2171,21 +1851,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1884",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1434 11TH, Anchorage, Alaska",
-          "Parcel": "108434000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 26A LT   4  G:1329",
-          "Valuation": "15665",
-          "formatted_address": "1434 W 11th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.21147610000001",
-          "lng": "-149.9112235"
-        }
+        "Permit": "R19-1884",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1434 11TH, Anchorage, Alaska",
+        "Parcel": "108434000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 26A LT   4  G:1329",
+        "Valuation": "15665",
+        "formatted_address": "1434 W 11th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2198,21 +1874,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1885",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1133 N, Anchorage, Alaska",
-          "Parcel": "108351000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 25A LT  16  G:1329",
-          "Valuation": "16314",
-          "formatted_address": "1133 N St, Anchorage, AK 99501, USA",
-          "lat": "61.2110192",
-          "lng": "-149.9075018"
-        }
+        "Permit": "R19-1885",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1133 N, Anchorage, Alaska",
+        "Parcel": "108351000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 25A LT  16  G:1329",
+        "Valuation": "16314",
+        "formatted_address": "1133 N St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2225,21 +1897,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1945",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3600 WYOMING, Anchorage, Alaska",
-          "Parcel": "1012510000",
-          "Units": "NA",
-          "Legal": "CONROY RUSHTON BLK   2 LT   1  G:1728",
-          "Valuation": "10798",
-          "formatted_address": "3600 Wyoming Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1878635",
-          "lng": "-149.9164071"
-        }
+        "Permit": "R19-1945",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3600 WYOMING, Anchorage, Alaska",
+        "Parcel": "1012510000",
+        "Units": "NA",
+        "Legal": "CONROY RUSHTON BLK   2 LT   1  G:1728",
+        "Valuation": "10798",
+        "formatted_address": "3600 Wyoming Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -2252,21 +1920,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1946",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1141 M, Anchorage, Alaska",
-          "Parcel": "108347000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 25A LT   4  G:1329",
-          "Valuation": "10797",
-          "formatted_address": "1141 M St, Anchorage, AK 99501, USA",
-          "lat": "61.21166780000001",
-          "lng": "-149.9057624"
-        }
+        "Permit": "R19-1946",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1141 M, Anchorage, Alaska",
+        "Parcel": "108347000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 25A LT   4  G:1329",
+        "Valuation": "10797",
+        "formatted_address": "1141 M St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2279,21 +1943,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1949",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "10340 KASILOF, Anchorage, Alaska",
-          "Parcel": "1513327000",
-          "Units": "NA",
-          "Legal": "KASILOF HILLS BLK  5 LT   1A  G:2541",
-          "Valuation": "22320",
-          "formatted_address": "10340 Kasilof Blvd, Anchorage, AK 99507, USA",
-          "lat": "61.1278499",
-          "lng": "-149.7225284"
-        }
+        "Permit": "R19-1949",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "10340 KASILOF, Anchorage, Alaska",
+        "Parcel": "1513327000",
+        "Units": "NA",
+        "Legal": "KASILOF HILLS BLK  5 LT   1A  G:2541",
+        "Valuation": "22320",
+        "formatted_address": "10340 Kasilof Blvd, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -2306,21 +1966,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1950",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "4130 DEFIANCE, Anchorage, Alaska",
-          "Parcel": "714514000",
-          "Units": "NA",
-          "Legal": "EASTLAKE ADDITION #1 BLK   2 LT   5  G:1738",
-          "Valuation": "8400",
-          "formatted_address": "4130 Defiance St, Anchorage, AK 99504, USA",
-          "lat": "61.18318219999999",
-          "lng": "-149.7706639"
-        }
+        "Permit": "R19-1950",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "4130 DEFIANCE, Anchorage, Alaska",
+        "Parcel": "714514000",
+        "Units": "NA",
+        "Legal": "EASTLAKE ADDITION #1 BLK   2 LT   5  G:1738",
+        "Valuation": "8400",
+        "formatted_address": "4130 Defiance St, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -2333,21 +1989,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1951",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1729 11TH, Anchorage, Alaska",
-          "Parcel": "107240000",
-          "Units": "NA",
-          "Legal": "L STREET SLIDE REPLAT PHASE 2 BLK 14 LT",
-          "Valuation": "24369",
-          "formatted_address": "1729 W 11th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2118787",
-          "lng": "-149.9176081"
-        }
+        "Permit": "R19-1951",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1729 11TH, Anchorage, Alaska",
+        "Parcel": "107240000",
+        "Units": "NA",
+        "Legal": "L STREET SLIDE REPLAT PHASE 2 BLK 14 LT",
+        "Valuation": "24369",
+        "formatted_address": "1729 W 11th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2360,21 +2012,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1952",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "8615 CORMORANT COVE, Anchorage, Alaska",
-          "Parcel": "1501602000",
-          "Units": "NA",
-          "Legal": "SAHALEE PHASE 3 BLK  2 LT  34  G:2336",
-          "Valuation": "13860",
-          "formatted_address": "8615 Cormorant Cove Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1427268",
-          "lng": "-149.7898353"
-        }
+        "Permit": "R19-1952",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "8615 CORMORANT COVE, Anchorage, Alaska",
+        "Parcel": "1501602000",
+        "Units": "NA",
+        "Legal": "SAHALEE PHASE 3 BLK  2 LT  34  G:2336",
+        "Valuation": "13860",
+        "formatted_address": "8615 Cormorant Cove Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -2387,21 +2035,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1973",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1113 N, Anchorage, Alaska",
-          "Parcel": "108368000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 25A LTS 14 W10' AND 15  G:1329",
-          "Valuation": "15930",
-          "formatted_address": "1113 N St, Anchorage, AK 99501, USA",
-          "lat": "61.2114533",
-          "lng": "-149.9074234"
-        }
+        "Permit": "R19-1973",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1113 N, Anchorage, Alaska",
+        "Parcel": "108368000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 25A LTS 14 W10' AND 15  G:1329",
+        "Valuation": "15930",
+        "formatted_address": "1113 N St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2414,21 +2058,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1976",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2613 ARLINGTON, Anchorage, Alaska",
-          "Parcel": "124304000",
-          "Units": "NA",
-          "Legal": "HUNTINGTON PARK #1 BLK  3 LT   2  G:1528",
-          "Valuation": "7000",
-          "formatted_address": "2613 Arlington Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1964759",
-          "lng": "-149.9209401"
-        }
+        "Permit": "R19-1976",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2613 ARLINGTON, Anchorage, Alaska",
+        "Parcel": "124304000",
+        "Units": "NA",
+        "Legal": "HUNTINGTON PARK #1 BLK  3 LT   2  G:1528",
+        "Valuation": "7000",
+        "formatted_address": "2613 Arlington Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -2441,21 +2081,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1977",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2131 MCKENZIE DRIVE, Anchorage, Alaska",
-          "Parcel": "119206000",
-          "Units": "NA",
-          "Legal": "PARK BLK   R LT  25  G:1526",
-          "Valuation": "16000",
-          "formatted_address": "2131 Mckenzie Dr, Anchorage, AK 99517, USA",
-          "lat": "61.20006609999999",
-          "lng": "-149.9498489"
-        }
+        "Permit": "R19-1977",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2131 MCKENZIE DRIVE, Anchorage, Alaska",
+        "Parcel": "119206000",
+        "Units": "NA",
+        "Legal": "PARK BLK   R LT  25  G:1526",
+        "Valuation": "16000",
+        "formatted_address": "2131 Mckenzie Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -2468,21 +2104,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1978",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2315 DOUGLAS DRIVE, Anchorage, Alaska",
-          "Parcel": "119120000",
-          "Units": "NA",
-          "Legal": "PARK BLK  M LT  24  G:1526",
-          "Valuation": "16000",
-          "formatted_address": "2315 Douglas Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19923189999999",
-          "lng": "-149.9445786"
-        }
+        "Permit": "R19-1978",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2315 DOUGLAS DRIVE, Anchorage, Alaska",
+        "Parcel": "119120000",
+        "Units": "NA",
+        "Legal": "PARK BLK  M LT  24  G:1526",
+        "Valuation": "16000",
+        "formatted_address": "2315 Douglas Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -2495,21 +2127,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1979",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3816 KNIK, Anchorage, Alaska",
-          "Parcel": "122542000",
-          "Units": "NA",
-          "Legal": "SIMONSON BLK 16A LT   5  G:1526",
-          "Valuation": "10000",
-          "formatted_address": "3816 Knik Ave, Anchorage, AK 99517, USA",
-          "lat": "61.1965349",
-          "lng": "-149.9564712"
-        }
+        "Permit": "R19-1979",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3816 KNIK, Anchorage, Alaska",
+        "Parcel": "122542000",
+        "Units": "NA",
+        "Legal": "SIMONSON BLK 16A LT   5  G:1526",
+        "Valuation": "10000",
+        "formatted_address": "3816 Knik Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -2522,21 +2150,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1980",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2551 FORAKER, Anchorage, Alaska",
-          "Parcel": "122237000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HOMES BLK  N LT  13  G:1526",
-          "Valuation": "16000",
-          "formatted_address": "2551 Foraker Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1970809",
-          "lng": "-149.9462855"
-        }
+        "Permit": "R19-1980",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2551 FORAKER, Anchorage, Alaska",
+        "Parcel": "122237000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HOMES BLK  N LT  13  G:1526",
+        "Valuation": "16000",
+        "formatted_address": "2551 Foraker Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -2549,21 +2173,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1981",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1775 FOREST PARK, Anchorage, Alaska",
-          "Parcel": "114333000",
-          "Units": "NA",
-          "Legal": "LAGOON ESTATES LT   4  G:1428",
-          "Valuation": "15000",
-          "formatted_address": "1775 Forest Park Dr, Anchorage, AK 99517, USA",
-          "lat": "61.2056365",
-          "lng": "-149.925656"
-        }
+        "Permit": "R19-1981",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1775 FOREST PARK, Anchorage, Alaska",
+        "Parcel": "114333000",
+        "Units": "NA",
+        "Legal": "LAGOON ESTATES LT   4  G:1428",
+        "Valuation": "15000",
+        "formatted_address": "1775 Forest Park Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -2576,21 +2196,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1982",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 3230 31ST, Anchorage, Alaska",
-          "Parcel": "1004353000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN SOUTH BLK  4 LT   5  G:1626",
-          "Valuation": "13000",
-          "formatted_address": "3230 W 31st Ave, Anchorage, AK 99517, USA",
-          "lat": "61.19236",
-          "lng": "-149.9444807"
-        }
+        "Permit": "R19-1982",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 3230 31ST, Anchorage, Alaska",
+        "Parcel": "1004353000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN SOUTH BLK  4 LT   5  G:1626",
+        "Valuation": "13000",
+        "formatted_address": "3230 W 31st Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -2603,21 +2219,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1983",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2001 HILLCREST, Anchorage, Alaska",
-          "Parcel": "114218000",
-          "Units": "NA",
-          "Legal": "LINGO LT  34A  G:1428",
-          "Valuation": "16000",
-          "formatted_address": "2001 Hillcrest Dr, Anchorage, AK 99517, USA",
-          "lat": "61.20304789999999",
-          "lng": "-149.9233078"
-        }
+        "Permit": "R19-1983",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2001 HILLCREST, Anchorage, Alaska",
+        "Parcel": "114218000",
+        "Units": "NA",
+        "Legal": "LINGO LT  34A  G:1428",
+        "Valuation": "16000",
+        "formatted_address": "2001 Hillcrest Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -2630,21 +2242,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-1984",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2451 SPURR LANE, Anchorage, Alaska",
-          "Parcel": "122437000",
-          "Units": "NA",
-          "Legal": "CHARLES G JONES LT 17  G:1526",
-          "Valuation": "14000",
-          "formatted_address": "2451 Spurr Ln, Anchorage, AK 99517, USA",
-          "lat": "61.19801159999999",
-          "lng": "-149.9554565"
-        }
+        "Permit": "R19-1984",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2451 SPURR LANE, Anchorage, Alaska",
+        "Parcel": "122437000",
+        "Units": "NA",
+        "Legal": "CHARLES G JONES LT 17  G:1526",
+        "Valuation": "14000",
+        "formatted_address": "2451 Spurr Ln, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -2657,21 +2265,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2050",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "11800 NEBESNA, Anchorage, Alaska",
-          "Parcel": "1524305000",
-          "Units": "NA",
-          "Legal": "ALPINE TERRACE BLK  2 LT   3  G:2740",
-          "Valuation": "18600",
-          "formatted_address": "11800 Nebesna Dr, Anchorage, AK 99507, USA",
-          "lat": "61.11363189999999",
-          "lng": "-149.7434429"
-        }
+        "Permit": "R19-2050",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "11800 NEBESNA, Anchorage, Alaska",
+        "Parcel": "1524305000",
+        "Units": "NA",
+        "Legal": "ALPINE TERRACE BLK  2 LT   3  G:2740",
+        "Valuation": "18600",
+        "formatted_address": "11800 Nebesna Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -2684,21 +2288,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2080",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1614 HIDDEN LANE, Anchorage, Alaska",
-          "Parcel": "110125000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 46 LT  10  G:1428",
-          "Valuation": "15445",
-          "formatted_address": "1614 Hidden Ln, Anchorage, AK 99501, USA",
-          "lat": "61.2063181",
-          "lng": "-149.913404"
-        }
+        "Permit": "R19-2080",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1614 HIDDEN LANE, Anchorage, Alaska",
+        "Parcel": "110125000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 46 LT  10  G:1428",
+        "Valuation": "15445",
+        "formatted_address": "1614 Hidden Ln, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2711,21 +2311,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2081",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1594 GARDEN STREET, Anchorage, Alaska",
-          "Parcel": "411232000",
-          "Units": "NA",
-          "Legal": "SAXTON BLK  3 LT   9  G:1434",
-          "Valuation": "13440",
-          "formatted_address": "1594 Garden St, Anchorage, AK 99508, USA",
-          "lat": "61.2062793",
-          "lng": "-149.825637"
-        }
+        "Permit": "R19-2081",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1594 GARDEN STREET, Anchorage, Alaska",
+        "Parcel": "411232000",
+        "Units": "NA",
+        "Legal": "SAXTON BLK  3 LT   9  G:1434",
+        "Valuation": "13440",
+        "formatted_address": "1594 Garden St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -2738,21 +2334,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2082",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1536 14TH, Anchorage, Alaska",
-          "Parcel": "110234000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 33D LT   4  G:1428",
-          "Valuation": "11790",
-          "formatted_address": "1536 E 14th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2086954",
-          "lng": "-149.8546246"
-        }
+        "Permit": "R19-2082",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1536 14TH, Anchorage, Alaska",
+        "Parcel": "110234000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 33D LT   4  G:1428",
+        "Valuation": "11790",
+        "formatted_address": "1536 E 14th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2765,21 +2357,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2083",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1327 H, Anchorage, Alaska",
-          "Parcel": "215643000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 37B LT   9  G:1430",
-          "Valuation": "12398",
-          "formatted_address": "1327 H St, Anchorage, AK 99501, USA",
-          "lat": "61.20913890000001",
-          "lng": "-149.8971393"
-        }
+        "Permit": "R19-2083",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1327 H, Anchorage, Alaska",
+        "Parcel": "215643000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 37B LT   9  G:1430",
+        "Valuation": "12398",
+        "formatted_address": "1327 H St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2792,21 +2380,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2092",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "14111 SUNVIEW, Anchorage, Alaska",
-          "Parcel": "1820148000",
-          "Units": "NA",
-          "Legal": "SUNSET HILLS BLK  B LT  25  G:3033",
-          "Valuation": "13440",
-          "formatted_address": "14111 Sunview Dr, Anchorage, AK 99515, USA",
-          "lat": "61.09296879999999",
-          "lng": "-149.8392184"
-        }
+        "Permit": "R19-2092",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "14111 SUNVIEW, Anchorage, Alaska",
+        "Parcel": "1820148000",
+        "Units": "NA",
+        "Legal": "SUNSET HILLS BLK  B LT  25  G:3033",
+        "Valuation": "13440",
+        "formatted_address": "14111 Sunview Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -2819,21 +2403,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2096",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1429 12TH, Anchorage, Alaska",
-          "Parcel": "108455000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 26A LT   8  G:1329",
-          "Valuation": "7470",
-          "formatted_address": "1429 W 12th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.21090939999999",
-          "lng": "-149.910966"
-        }
+        "Permit": "R19-2096",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1429 12TH, Anchorage, Alaska",
+        "Parcel": "108455000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 26A LT   8  G:1329",
+        "Valuation": "7470",
+        "formatted_address": "1429 W 12th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2846,21 +2426,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2097",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1406 13TH, Anchorage, Alaska",
-          "Parcel": "109615000",
-          "Units": "NA",
-          "Legal": "VIEW RIDGE (OF SOUTH ADDN) BLK 34A LT   1  G:1429",
-          "Valuation": "12810",
-          "formatted_address": "1406 W 13th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2095187",
-          "lng": "-149.9103283"
-        }
+        "Permit": "R19-2097",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1406 13TH, Anchorage, Alaska",
+        "Parcel": "109615000",
+        "Units": "NA",
+        "Legal": "VIEW RIDGE (OF SOUTH ADDN) BLK 34A LT   1  G:1429",
+        "Valuation": "12810",
+        "formatted_address": "1406 W 13th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2873,21 +2449,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2121",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "920 R, Anchorage, Alaska",
-          "Parcel": "107223000",
-          "Units": "NA",
-          "Legal": "L STREET SLIDE REPLAT PHASE 2 BLK 13B LT",
-          "Valuation": "15120",
-          "formatted_address": "920 R St, Anchorage, AK 99501, USA",
-          "lat": "61.2130287",
-          "lng": "-149.9139468"
-        }
+        "Permit": "R19-2121",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "920 R, Anchorage, Alaska",
+        "Parcel": "107223000",
+        "Units": "NA",
+        "Legal": "L STREET SLIDE REPLAT PHASE 2 BLK 13B LT",
+        "Valuation": "15120",
+        "formatted_address": "920 R St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2900,21 +2472,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2122",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1517 15TH, Anchorage, Alaska",
-          "Parcel": "110240000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 33D LT   8  G:1428",
-          "Valuation": "17010",
-          "formatted_address": "1517 E 15th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.20775310000001",
-          "lng": "-149.85438920000001"
-        }
+        "Permit": "R19-2122",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1517 15TH, Anchorage, Alaska",
+        "Parcel": "110240000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 33D LT   8  G:1428",
+        "Valuation": "17010",
+        "formatted_address": "1517 E 15th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2927,21 +2495,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2123",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1529 E, Anchorage, Alaska",
-          "Parcel": "215325000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 40A LT   8  G:1430",
-          "Valuation": "10395",
-          "formatted_address": "1529 E St, Anchorage, AK 99501, USA",
-          "lat": "61.2070362",
-          "lng": "-149.8910177"
-        }
+        "Permit": "R19-2123",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1529 E, Anchorage, Alaska",
+        "Parcel": "215325000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 40A LT   8  G:1430",
+        "Valuation": "10395",
+        "formatted_address": "1529 E St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -2954,21 +2518,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2124",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "24242 ALPENGLOW, Anchorage, Alaska",
-          "Parcel": "5061133000",
-          "Units": "NA",
-          "Legal": "HAMANN LT  7A  G:0161",
-          "Valuation": "33630",
-          "formatted_address": "24242 Alpenglow Dr, Eagle River, AK 99577, USA",
-          "lat": "61.2966476",
-          "lng": "-149.4292855"
-        }
+        "Permit": "R19-2124",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "24242 ALPENGLOW, Anchorage, Alaska",
+        "Parcel": "5061133000",
+        "Units": "NA",
+        "Legal": "HAMANN LT  7A  G:0161",
+        "Valuation": "33630",
+        "formatted_address": "24242 Alpenglow Dr, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -2981,21 +2541,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2127",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "9410 NETTLETON, Anchorage, Alaska",
-          "Parcel": "1506262000",
-          "Units": "NA",
-          "Legal": "NETTLETON ACRES #1 LT  1  G:2439",
-          "Valuation": "25655",
-          "formatted_address": "9410 Nettleton Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1355593",
-          "lng": "-149.7452964"
-        }
+        "Permit": "R19-2127",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "9410 NETTLETON, Anchorage, Alaska",
+        "Parcel": "1506262000",
+        "Units": "NA",
+        "Legal": "NETTLETON ACRES #1 LT  1  G:2439",
+        "Valuation": "25655",
+        "formatted_address": "9410 Nettleton Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -3008,21 +2564,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2128",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "17001 ARIES COURT, Anchorage, Alaska",
-          "Parcel": "2009130000",
-          "Units": "NA",
-          "Legal": "SUSITNA VIEW ESTATES BLK  3 LT   8  G:3336",
-          "Valuation": "17990",
-          "formatted_address": "17001 Aries Ct, Anchorage, AK 99516, USA",
-          "lat": "61.06662029999999",
-          "lng": "-149.78978"
-        }
+        "Permit": "R19-2128",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "17001 ARIES COURT, Anchorage, Alaska",
+        "Parcel": "2009130000",
+        "Units": "NA",
+        "Legal": "SUSITNA VIEW ESTATES BLK  3 LT   8  G:3336",
+        "Valuation": "17990",
+        "formatted_address": "17001 Aries Ct, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -3035,21 +2587,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2161",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1319 11TH, Anchorage, Alaska",
-          "Parcel": "108490000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK  15B LT   9 E23' & LT 10  G:1329",
-          "Valuation": "18225",
-          "formatted_address": "1319 W 11th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2119027",
-          "lng": "-149.908796"
-        }
+        "Permit": "R19-2161",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1319 11TH, Anchorage, Alaska",
+        "Parcel": "108490000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK  15B LT   9 E23' & LT 10  G:1329",
+        "Valuation": "18225",
+        "formatted_address": "1319 W 11th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -3062,21 +2610,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2164",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1426 G, Anchorage, Alaska",
-          "Parcel": "215610000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 37C LT   4  G:1430",
-          "Valuation": "19300",
-          "formatted_address": "1426 G St, Anchorage, AK 99501, USA",
-          "lat": "61.2081561",
-          "lng": "-149.8962109"
-        }
+        "Permit": "R19-2164",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1426 G, Anchorage, Alaska",
+        "Parcel": "215610000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 37C LT   4  G:1430",
+        "Valuation": "19300",
+        "formatted_address": "1426 G St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -3089,21 +2633,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2172",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 3735 35TH, Anchorage, Alaska",
-          "Parcel": "1007226000",
-          "Units": "NA",
-          "Legal": "HAWTHORNE BLK  1 LT   6  G:1626",
-          "Valuation": "17500",
-          "formatted_address": "3735 W 35th Ave, Anchorage, AK 99517, USA",
-          "lat": "61.1891764",
-          "lng": "-149.9553572"
-        }
+        "Permit": "R19-2172",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 3735 35TH, Anchorage, Alaska",
+        "Parcel": "1007226000",
+        "Units": "NA",
+        "Legal": "HAWTHORNE BLK  1 LT   6  G:1626",
+        "Valuation": "17500",
+        "formatted_address": "3735 W 35th Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3116,21 +2656,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2173",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2439 DOUGLAS DRIVE, Anchorage, Alaska",
-          "Parcel": "122213000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HOMES BLK  M LT  29  G:1526",
-          "Valuation": "11000",
-          "formatted_address": "2439 Douglas Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1982124",
-          "lng": "-149.9445277"
-        }
+        "Permit": "R19-2173",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2439 DOUGLAS DRIVE, Anchorage, Alaska",
+        "Parcel": "122213000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HOMES BLK  M LT  29  G:1526",
+        "Valuation": "11000",
+        "formatted_address": "2439 Douglas Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3143,21 +2679,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2174",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3640 CLAY PRODUCTS, Anchorage, Alaska",
-          "Parcel": "122511000",
-          "Units": "NA",
-          "Legal": "HOLIFIELD LT  5  G:1526",
-          "Valuation": "13000",
-          "formatted_address": "3640 Clay Products Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19736869999999",
-          "lng": "-149.9536484"
-        }
+        "Permit": "R19-2174",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3640 CLAY PRODUCTS, Anchorage, Alaska",
+        "Parcel": "122511000",
+        "Units": "NA",
+        "Legal": "HOLIFIELD LT  5  G:1526",
+        "Valuation": "13000",
+        "formatted_address": "3640 Clay Products Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3170,21 +2702,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2175",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2437 LOUSSAC, Anchorage, Alaska",
-          "Parcel": "123329000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HEIGHTS #1 BLK  B LT  21  G:1527",
-          "Valuation": "14000",
-          "formatted_address": "2437 Loussac Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1984715",
-          "lng": "-149.934073"
-        }
+        "Permit": "R19-2175",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2437 LOUSSAC, Anchorage, Alaska",
+        "Parcel": "123329000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HEIGHTS #1 BLK  B LT  21  G:1527",
+        "Valuation": "14000",
+        "formatted_address": "2437 Loussac Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3197,21 +2725,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2212",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1601 KEPNER, Anchorage, Alaska",
-          "Parcel": "623317000",
-          "Units": "NA",
-          "Legal": "NUNAKA VALLEY BLK  B LT  28  G:1438",
-          "Valuation": "19990",
-          "formatted_address": "1601 Kepner Dr, Anchorage, AK 99504, USA",
-          "lat": "61.2061388",
-          "lng": "-149.7670999"
-        }
+        "Permit": "R19-2212",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1601 KEPNER, Anchorage, Alaska",
+        "Parcel": "623317000",
+        "Units": "NA",
+        "Legal": "NUNAKA VALLEY BLK  B LT  28  G:1438",
+        "Valuation": "19990",
+        "formatted_address": "1601 Kepner Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -3224,21 +2748,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2264",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3620 CLAY PRODUCTS, Anchorage, Alaska",
-          "Parcel": "122513000",
-          "Units": "NA",
-          "Legal": "HOLIFIELD LT  3  G:1526",
-          "Valuation": "15000",
-          "formatted_address": "3620 Clay Products Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19729169999999",
-          "lng": "-149.9529968"
-        }
+        "Permit": "R19-2264",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3620 CLAY PRODUCTS, Anchorage, Alaska",
+        "Parcel": "122513000",
+        "Units": "NA",
+        "Legal": "HOLIFIELD LT  3  G:1526",
+        "Valuation": "15000",
+        "formatted_address": "3620 Clay Products Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3251,21 +2771,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2265",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2100 FORAKER, Anchorage, Alaska",
-          "Parcel": "119212000",
-          "Units": "NA",
-          "Legal": "PARK BLK   R LT  19  G:1526",
-          "Valuation": "15000",
-          "formatted_address": "2100 Foraker Dr, Anchorage, AK 99517, USA",
-          "lat": "61.2005368",
-          "lng": "-149.9478591"
-        }
+        "Permit": "R19-2265",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2100 FORAKER, Anchorage, Alaska",
+        "Parcel": "119212000",
+        "Units": "NA",
+        "Legal": "PARK BLK   R LT  19  G:1526",
+        "Valuation": "15000",
+        "formatted_address": "2100 Foraker Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3278,21 +2794,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2272",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1342 12TH, Anchorage, Alaska",
-          "Parcel": "108462000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 26D LT   2B  G:1329",
-          "Valuation": "15045",
-          "formatted_address": "1342 W 12th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.21047419999999",
-          "lng": "-149.9100103"
-        }
+        "Permit": "R19-2272",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1342 12TH, Anchorage, Alaska",
+        "Parcel": "108462000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 26D LT   2B  G:1329",
+        "Valuation": "15045",
+        "formatted_address": "1342 W 12th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -3305,21 +2817,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2273",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3764 HENDERSON, Anchorage, Alaska",
-          "Parcel": "1408138000",
-          "Units": "NA",
-          "Legal": "GATEWAY BLK  2 LT   3  G:2135",
-          "Valuation": "12280",
-          "formatted_address": "3764 Henderson Loop, Anchorage, AK 99507, USA",
-          "lat": "61.1564478",
-          "lng": "-149.8132095"
-        }
+        "Permit": "R19-2273",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3764 HENDERSON, Anchorage, Alaska",
+        "Parcel": "1408138000",
+        "Units": "NA",
+        "Legal": "GATEWAY BLK  2 LT   3  G:2135",
+        "Valuation": "12280",
+        "formatted_address": "3764 Henderson Loop, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -3332,21 +2840,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2274",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1123 I STREET, Anchorage, Alaska",
-          "Parcel": "108133000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 23A LT   8B  G:1329",
-          "Valuation": "18100",
-          "formatted_address": "1123 I St, Anchorage, AK 99501, USA",
-          "lat": "61.211186",
-          "lng": "-149.8988352"
-        }
+        "Permit": "R19-2274",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1123 I STREET, Anchorage, Alaska",
+        "Parcel": "108133000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 23A LT   8B  G:1329",
+        "Valuation": "18100",
+        "formatted_address": "1123 I St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -3359,21 +2863,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2281",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1351 U STREET, Anchorage, Alaska",
-          "Parcel": "110616000",
-          "Units": "NA",
-          "Legal": "BOOTLEGGER PARK BLK  1 LT  16  G:1428",
-          "Valuation": "19566",
-          "formatted_address": "1351 U St, Anchorage, AK 99501, USA",
-          "lat": "61.2084123",
-          "lng": "-149.9207864"
-        }
+        "Permit": "R19-2281",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1351 U STREET, Anchorage, Alaska",
+        "Parcel": "110616000",
+        "Units": "NA",
+        "Legal": "BOOTLEGGER PARK BLK  1 LT  16  G:1428",
+        "Valuation": "19566",
+        "formatted_address": "1351 U St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -3386,21 +2886,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2355",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1353 U STREET, Anchorage, Alaska",
-          "Parcel": "110615000",
-          "Units": "NA",
-          "Legal": "BOOTLEGGER PARK BLK  1 LT  15  G:1428",
-          "Valuation": "18900",
-          "formatted_address": "1353 U St, Anchorage, AK 99501, USA",
-          "lat": "61.20872739999999",
-          "lng": "-149.9195517"
-        }
+        "Permit": "R19-2355",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1353 U STREET, Anchorage, Alaska",
+        "Parcel": "110615000",
+        "Units": "NA",
+        "Legal": "BOOTLEGGER PARK BLK  1 LT  15  G:1428",
+        "Valuation": "18900",
+        "formatted_address": "1353 U St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -3413,21 +2909,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2356",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2205 HILAND, Anchorage, Alaska",
-          "Parcel": "7814118000",
-          "Units": "NA",
-          "Legal": "SOUTHFORK NORTH BLK  1 LT   2  G:0959",
-          "Valuation": "28008",
-          "formatted_address": "2205 Hiland Rd, Eagle River, AK 99577, USA",
-          "lat": "61.2407713",
-          "lng": "-149.4516106"
-        }
+        "Permit": "R19-2356",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2205 HILAND, Anchorage, Alaska",
+        "Parcel": "7814118000",
+        "Units": "NA",
+        "Legal": "SOUTHFORK NORTH BLK  1 LT   2  G:0959",
+        "Valuation": "28008",
+        "formatted_address": "2205 Hiland Rd, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -3440,21 +2932,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2359",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "E 923 11TH, Anchorage, Alaska",
-          "Parcel": "311524000",
-          "Units": "NA",
-          "Legal": "BEVERS (THIRD ADDN) BLK   4C LT  10 G:1332",
-          "Valuation": "17280",
-          "formatted_address": "923 E St, Anchorage, AK 99501, USA",
-          "lat": "61.2133322",
-          "lng": "-149.8911654"
-        }
+        "Permit": "R19-2359",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "E 923 11TH, Anchorage, Alaska",
+        "Parcel": "311524000",
+        "Units": "NA",
+        "Legal": "BEVERS (THIRD ADDN) BLK   4C LT  10 G:1332",
+        "Valuation": "17280",
+        "formatted_address": "923 E St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -3467,21 +2955,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2377",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2261 FOXHALL, Anchorage, Alaska",
-          "Parcel": "627218000",
-          "Units": "NA",
-          "Legal": "FOXHALL #1 BLK  1 LT  51  G:1539",
-          "Valuation": "13500",
-          "formatted_address": "2261 Foxhall Dr, Anchorage, AK 99504, USA",
-          "lat": "61.2002167",
-          "lng": "-149.7525693"
-        }
+        "Permit": "R19-2377",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2261 FOXHALL, Anchorage, Alaska",
+        "Parcel": "627218000",
+        "Units": "NA",
+        "Legal": "FOXHALL #1 BLK  1 LT  51  G:1539",
+        "Valuation": "13500",
+        "formatted_address": "2261 Foxhall Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -3494,21 +2978,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2428",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2727 HILAND, Anchorage, Alaska",
-          "Parcel": "7816109000",
-          "Units": "NA",
-          "Legal": "CHUGACH HILLS BLK  1 LT   1A  G:0959",
-          "Valuation": "12600",
-          "formatted_address": "2727 Hiland Rd, Eagle River, AK 99577, USA",
-          "lat": "61.24500699999999",
-          "lng": "-149.4564432"
-        }
+        "Permit": "R19-2428",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2727 HILAND, Anchorage, Alaska",
+        "Parcel": "7816109000",
+        "Units": "NA",
+        "Legal": "CHUGACH HILLS BLK  1 LT   1A  G:0959",
+        "Valuation": "12600",
+        "formatted_address": "2727 Hiland Rd, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -3521,21 +3001,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2458",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1322 N, Anchorage, Alaska",
-          "Parcel": "109604000",
-          "Units": "NA",
-          "Legal": "VIEW RIDGE (OF SOUTH ADDN) BLK 34B LT   4  G:1429",
-          "Valuation": "22850",
-          "formatted_address": "1322 N St, Anchorage, AK 99501, USA",
-          "lat": "61.2091272",
-          "lng": "-149.9082615"
-        }
+        "Permit": "R19-2458",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1322 N, Anchorage, Alaska",
+        "Parcel": "109604000",
+        "Units": "NA",
+        "Legal": "VIEW RIDGE (OF SOUTH ADDN) BLK 34B LT   4  G:1429",
+        "Valuation": "22850",
+        "formatted_address": "1322 N St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -3548,21 +3024,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2459",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 3332 83RD, Anchorage, Alaska",
-          "Parcel": "1225218000",
-          "Units": "NA",
-          "Legal": "MCWILLIAMS BLK  2A LT   3  G:2226",
-          "Valuation": "13230",
-          "formatted_address": "3332 W 83rd Ave, Anchorage, AK 99502, USA",
-          "lat": "61.14547820000001",
-          "lng": "-149.9418065"
-        }
+        "Permit": "R19-2459",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 3332 83RD, Anchorage, Alaska",
+        "Parcel": "1225218000",
+        "Units": "NA",
+        "Legal": "MCWILLIAMS BLK  2A LT   3  G:2226",
+        "Valuation": "13230",
+        "formatted_address": "3332 W 83rd Ave, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -3575,21 +3047,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2460",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3116 PRINCETON, Anchorage, Alaska",
-          "Parcel": "321613000",
-          "Units": "NA",
-          "Legal": "COLLEGE VILLAGE # 6 BLK 15 LT   2  G:1633",
-          "Valuation": "22320",
-          "formatted_address": "3116 Princeton Way, Anchorage, AK 99508, USA",
-          "lat": "61.1917151",
-          "lng": "-149.8485355"
-        }
+        "Permit": "R19-2460",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3116 PRINCETON, Anchorage, Alaska",
+        "Parcel": "321613000",
+        "Units": "NA",
+        "Legal": "COLLEGE VILLAGE # 6 BLK 15 LT   2  G:1633",
+        "Valuation": "22320",
+        "formatted_address": "3116 Princeton Way, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -3602,21 +3070,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2461",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 621 15TH, Anchorage, Alaska",
-          "Parcel": "215519000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 38D LT   3  G:1430",
-          "Valuation": "13650",
-          "formatted_address": "621 E 15th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.20792290000001",
-          "lng": "-149.8726686"
-        }
+        "Permit": "R19-2461",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 621 15TH, Anchorage, Alaska",
+        "Parcel": "215519000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 38D LT   3  G:1430",
+        "Valuation": "13650",
+        "formatted_address": "621 E 15th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -3629,21 +3093,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2462",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2727 HILAND, Anchorage, Alaska",
-          "Parcel": "7816109000",
-          "Units": "NA",
-          "Legal": "CHUGACH HILLS BLK  1 LT   1A  G:0959",
-          "Valuation": "12600",
-          "formatted_address": "2727 Hiland Rd, Eagle River, AK 99577, USA",
-          "lat": "61.24500699999999",
-          "lng": "-149.4564432"
-        }
+        "Permit": "R19-2462",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2727 HILAND, Anchorage, Alaska",
+        "Parcel": "7816109000",
+        "Units": "NA",
+        "Legal": "CHUGACH HILLS BLK  1 LT   1A  G:0959",
+        "Valuation": "12600",
+        "formatted_address": "2727 Hiland Rd, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -3656,21 +3116,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2463",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3861 CHINIAK BAY, Anchorage, Alaska",
-          "Parcel": "1140102000",
-          "Units": "NA",
-          "Legal": "BAYSHORE WEST #2 BLK  5 LT   1  G:2525",
-          "Valuation": "72540",
-          "formatted_address": "3861 Chiniak Bay Dr, Anchorage, AK 99515, USA",
-          "lat": "61.1247053",
-          "lng": "-149.95395"
-        }
+        "Permit": "R19-2463",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3861 CHINIAK BAY, Anchorage, Alaska",
+        "Parcel": "1140102000",
+        "Units": "NA",
+        "Legal": "BAYSHORE WEST #2 BLK  5 LT   1  G:2525",
+        "Valuation": "72540",
+        "formatted_address": "3861 Chiniak Bay Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -3683,21 +3139,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2526",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3561 NOVA, Anchorage, Alaska",
-          "Parcel": "1006339000",
-          "Units": "NA",
-          "Legal": "SATELLITE PARK #1 BLK  1 LT  20A  G:1625",
-          "Valuation": "15000",
-          "formatted_address": "3561 Nova Cir, Anchorage, AK 99517, USA",
-          "lat": "61.18824739999999",
-          "lng": "-149.9628323"
-        }
+        "Permit": "R19-2526",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3561 NOVA, Anchorage, Alaska",
+        "Parcel": "1006339000",
+        "Units": "NA",
+        "Legal": "SATELLITE PARK #1 BLK  1 LT  20A  G:1625",
+        "Valuation": "15000",
+        "formatted_address": "3561 Nova Cir, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3710,21 +3162,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2527",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2112 ESQUIRE DRIVE, Anchorage, Alaska",
-          "Parcel": "117531000",
-          "Units": "NA",
-          "Legal": "FOREST PARK LT  13 G:1528",
-          "Valuation": "20000",
-          "formatted_address": "2112 Esquire Dr, Anchorage, AK 99517, USA",
-          "lat": "61.2013986",
-          "lng": "-149.9263465"
-        }
+        "Permit": "R19-2527",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2112 ESQUIRE DRIVE, Anchorage, Alaska",
+        "Parcel": "117531000",
+        "Units": "NA",
+        "Legal": "FOREST PARK LT  13 G:1528",
+        "Valuation": "20000",
+        "formatted_address": "2112 Esquire Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3737,21 +3185,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2528",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2266 SAINT ELIAS, Anchorage, Alaska",
-          "Parcel": "118423000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HOMES BLK  L LT   7  G:1527",
-          "Valuation": "20000",
-          "formatted_address": "2266 St Elias Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19992869999999",
-          "lng": "-149.9420718"
-        }
+        "Permit": "R19-2528",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2266 SAINT ELIAS, Anchorage, Alaska",
+        "Parcel": "118423000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HOMES BLK  L LT   7  G:1527",
+        "Valuation": "20000",
+        "formatted_address": "2266 St Elias Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3764,21 +3208,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2529",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3850 KNIK, Anchorage, Alaska",
-          "Parcel": "122541000",
-          "Units": "NA",
-          "Legal": "SIMONSON BLK 16A LT   6  G:1526",
-          "Valuation": "15000",
-          "formatted_address": "3850 Knik Ave, Anchorage, AK 99517, USA",
-          "lat": "61.19682289999999",
-          "lng": "-149.956568"
-        }
+        "Permit": "R19-2529",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3850 KNIK, Anchorage, Alaska",
+        "Parcel": "122541000",
+        "Units": "NA",
+        "Legal": "SIMONSON BLK 16A LT   6  G:1526",
+        "Valuation": "15000",
+        "formatted_address": "3850 Knik Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3791,21 +3231,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2530",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3724 KNIK, Anchorage, Alaska",
-          "Parcel": "122546000",
-          "Units": "NA",
-          "Legal": "SIMONSON BLK 16A LT   1  G:1526",
-          "Valuation": "13000",
-          "formatted_address": "3724 Knik Ave, Anchorage, AK 99517, USA",
-          "lat": "61.1964256",
-          "lng": "-149.9551472"
-        }
+        "Permit": "R19-2530",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3724 KNIK, Anchorage, Alaska",
+        "Parcel": "122546000",
+        "Units": "NA",
+        "Legal": "SIMONSON BLK 16A LT   1  G:1526",
+        "Valuation": "13000",
+        "formatted_address": "3724 Knik Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3818,21 +3254,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2531",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2513 LORD BARANOF, Anchorage, Alaska",
-          "Parcel": "123305000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HOMES BLK   D LT 28A  G:1527",
-          "Valuation": "15000",
-          "formatted_address": "2513 Lord Baranof Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19762100000001",
-          "lng": "-149.9359245"
-        }
+        "Permit": "R19-2531",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2513 LORD BARANOF, Anchorage, Alaska",
+        "Parcel": "123305000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HOMES BLK   D LT 28A  G:1527",
+        "Valuation": "15000",
+        "formatted_address": "2513 Lord Baranof Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3845,21 +3277,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2533",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "4100 BALCHEN, Anchorage, Alaska",
-          "Parcel": "1019128000",
-          "Units": "NA",
-          "Legal": "BROADMOOR ESTATES BLK  2 LT  21  G:1727",
-          "Valuation": "15000",
-          "formatted_address": "4100 Balchen Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1838058",
-          "lng": "-149.940588"
-        }
+        "Permit": "R19-2533",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "4100 BALCHEN, Anchorage, Alaska",
+        "Parcel": "1019128000",
+        "Units": "NA",
+        "Legal": "BROADMOOR ESTATES BLK  2 LT  21  G:1727",
+        "Valuation": "15000",
+        "formatted_address": "4100 Balchen Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3872,21 +3300,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2534",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2100 FORAKER, Anchorage, Alaska",
-          "Parcel": "119212000",
-          "Units": "NA",
-          "Legal": "PARK BLK   R LT  19  G:1526",
-          "Valuation": "15000",
-          "formatted_address": "2100 Foraker Dr, Anchorage, AK 99517, USA",
-          "lat": "61.2005368",
-          "lng": "-149.9478591"
-        }
+        "Permit": "R19-2534",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2100 FORAKER, Anchorage, Alaska",
+        "Parcel": "119212000",
+        "Units": "NA",
+        "Legal": "PARK BLK   R LT  19  G:1526",
+        "Valuation": "15000",
+        "formatted_address": "2100 Foraker Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -3899,21 +3323,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2584",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1210 N, Anchorage, Alaska",
-          "Parcel": "108468000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 26C LT   1  G:1329",
-          "Valuation": "10150",
-          "formatted_address": "1210 N St, Anchorage, AK 99501, USA",
-          "lat": "61.21038799999999",
-          "lng": "-149.9081163"
-        }
+        "Permit": "R19-2584",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1210 N, Anchorage, Alaska",
+        "Parcel": "108468000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 26C LT   1  G:1329",
+        "Valuation": "10150",
+        "formatted_address": "1210 N St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -3926,21 +3346,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2585",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3404 LAKESIDE, Anchorage, Alaska",
-          "Parcel": "1242124000",
-          "Units": "NA",
-          "Legal": "CAMPBELL LAKE HEIGHTS BLK  1 LT  16  G:2426",
-          "Valuation": "19800",
-          "formatted_address": "3404 Lakeside Dr, Anchorage, AK 99515, USA",
-          "lat": "61.13117069999999",
-          "lng": "-149.9431428"
-        }
+        "Permit": "R19-2585",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3404 LAKESIDE, Anchorage, Alaska",
+        "Parcel": "1242124000",
+        "Units": "NA",
+        "Legal": "CAMPBELL LAKE HEIGHTS BLK  1 LT  16  G:2426",
+        "Valuation": "19800",
+        "formatted_address": "3404 Lakeside Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -3953,21 +3369,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2586",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 1228 15TH, Anchorage, Alaska",
-          "Parcel": "109453000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 44A LT   2A  G:1429",
-          "Valuation": "14930",
-          "formatted_address": "1228 E 15th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2076437",
-          "lng": "-149.8601626"
-        }
+        "Permit": "R19-2586",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 1228 15TH, Anchorage, Alaska",
+        "Parcel": "109453000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 44A LT   2A  G:1429",
+        "Valuation": "14930",
+        "formatted_address": "1228 E 15th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -3980,21 +3392,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2589",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1525 HIDDEN LANE, Anchorage, Alaska",
-          "Parcel": "110114000",
-          "Units": "NA",
-          "Legal": "SOUTH ADDITION BLK 46 LT  19  G:1428",
-          "Valuation": "1597",
-          "formatted_address": "1525 Hidden Ln, Anchorage, AK 99501, USA",
-          "lat": "61.20722790000001",
-          "lng": "-149.9142409"
-        }
+        "Permit": "R19-2589",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1525 HIDDEN LANE, Anchorage, Alaska",
+        "Parcel": "110114000",
+        "Units": "NA",
+        "Legal": "SOUTH ADDITION BLK 46 LT  19  G:1428",
+        "Valuation": "1597",
+        "formatted_address": "1525 Hidden Ln, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -4007,21 +3415,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2627",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "E 115 11TH, Anchorage, Alaska",
-          "Parcel": "213654000",
-          "Units": "NA",
-          "Legal": "THIRD ADDITION BLK 13 LT  26  G:1331",
-          "Valuation": "12951",
-          "formatted_address": "115 W 11th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2118961",
-          "lng": "-149.8839487"
-        }
+        "Permit": "R19-2627",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "E 115 11TH, Anchorage, Alaska",
+        "Parcel": "213654000",
+        "Units": "NA",
+        "Legal": "THIRD ADDITION BLK 13 LT  26  G:1331",
+        "Valuation": "12951",
+        "formatted_address": "115 W 11th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -4034,21 +3438,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2628",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "E 2825 18TH, Anchorage, Alaska",
-          "Parcel": "414244000",
-          "Units": "NA",
-          "Legal": "SAXTON BLK  9 LT   9  G:1434",
-          "Valuation": "11880",
-          "formatted_address": "2825 E 18th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.2045459",
-          "lng": "-149.8276098"
-        }
+        "Permit": "R19-2628",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "E 2825 18TH, Anchorage, Alaska",
+        "Parcel": "414244000",
+        "Units": "NA",
+        "Legal": "SAXTON BLK  9 LT   9  G:1434",
+        "Valuation": "11880",
+        "formatted_address": "2825 E 18th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -4061,21 +3461,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2636",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1518 K, Anchorage, Alaska",
-          "Parcel": "109314000",
-          "Units": "NA",
-          "Legal": "MARTIN AND WELCH (SOUTH ADD) BLK 43A LT",
-          "Valuation": "12100",
-          "formatted_address": "1518 K St, Anchorage, AK 99501, USA",
-          "lat": "61.2073321",
-          "lng": "-149.9023132"
-        }
+        "Permit": "R19-2636",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1518 K, Anchorage, Alaska",
+        "Parcel": "109314000",
+        "Units": "NA",
+        "Legal": "MARTIN AND WELCH (SOUTH ADD) BLK 43A LT",
+        "Valuation": "12100",
+        "formatted_address": "1518 K St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -4088,21 +3484,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2637",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 2108 46TH, Anchorage, Alaska",
-          "Parcel": "1023316000",
-          "Units": "NA",
-          "Legal": "NORTH STAR BLK  D LT  11  G:1828",
-          "Valuation": "9735",
-          "formatted_address": "2108 W 46th Ave, Anchorage, AK 99517, USA",
-          "lat": "61.17875180000001",
-          "lng": "-149.9228011"
-        }
+        "Permit": "R19-2637",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 2108 46TH, Anchorage, Alaska",
+        "Parcel": "1023316000",
+        "Units": "NA",
+        "Legal": "NORTH STAR BLK  D LT  11  G:1828",
+        "Valuation": "9735",
+        "formatted_address": "2108 W 46th Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -4115,21 +3507,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2664\n",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "W 2423 MARSTON, Anchorage, Alaska",
-          "Parcel": "122423000",
-          "Units": "NA",
-          "Legal": "SIMONSON ESTATES BLK",
-          "Valuation": "16000",
-          "formatted_address": "2423 Marston Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19852479999999",
-          "lng": "-149.9539417"
-        }
+        "Permit": "R19-2664\n",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "W 2423 MARSTON, Anchorage, Alaska",
+        "Parcel": "122423000",
+        "Units": "NA",
+        "Legal": "SIMONSON ESTATES BLK",
+        "Valuation": "16000",
+        "formatted_address": "2423 Marston Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -4142,21 +3530,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2668",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2426 SUSITNA, Anchorage, Alaska",
-          "Parcel": "122324000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HOMES BLK  R LT 8  G:1526",
-          "Valuation": "16000",
-          "formatted_address": "2426 Susitna Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1983852",
-          "lng": "-149.9489457"
-        }
+        "Permit": "R19-2668",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2426 SUSITNA, Anchorage, Alaska",
+        "Parcel": "122324000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HOMES BLK  R LT 8  G:1526",
+        "Valuation": "16000",
+        "formatted_address": "2426 Susitna Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -4169,21 +3553,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2767",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "4046 WESTWOOD, Anchorage, Alaska",
-          "Parcel": "121153000",
-          "Units": "NA",
-          "Legal": "WEST TURNAGAIN BLK  2 LT   8  G:1525",
-          "Valuation": "25000",
-          "formatted_address": "4046 Westwood Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1964378",
-          "lng": "-149.9600428"
-        }
+        "Permit": "R19-2767",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "4046 WESTWOOD, Anchorage, Alaska",
+        "Parcel": "121153000",
+        "Units": "NA",
+        "Legal": "WEST TURNAGAIN BLK  2 LT   8  G:1525",
+        "Valuation": "25000",
+        "formatted_address": "4046 Westwood Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -4196,21 +3576,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2818",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2831 WILEY POST, Anchorage, Alaska",
-          "Parcel": "1013108000",
-          "Units": "NA",
-          "Legal": "BROADMOOR ESTATES #2 BLK  9 LT  19  G:1727",
-          "Valuation": "16170",
-          "formatted_address": "2831 Wiley Post Ave, Anchorage, AK 99517, USA",
-          "lat": "61.1874687",
-          "lng": "-149.9369557"
-        }
+        "Permit": "R19-2818",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2831 WILEY POST, Anchorage, Alaska",
+        "Parcel": "1013108000",
+        "Units": "NA",
+        "Legal": "BROADMOOR ESTATES #2 BLK  9 LT  19  G:1727",
+        "Valuation": "16170",
+        "formatted_address": "2831 Wiley Post Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -4223,21 +3599,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2827",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2501 SUSITNA, Anchorage, Alaska",
-          "Parcel": "122317000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN HOMES BLK  Q LT  23  G:1526",
-          "Valuation": "15000",
-          "formatted_address": "2501 Susitna Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1980166",
-          "lng": "-149.9479819"
-        }
+        "Permit": "R19-2827",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2501 SUSITNA, Anchorage, Alaska",
+        "Parcel": "122317000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN HOMES BLK  Q LT  23  G:1526",
+        "Valuation": "15000",
+        "formatted_address": "2501 Susitna Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -4250,21 +3622,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2848",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3205 WYOMING, Anchorage, Alaska",
-          "Parcel": "1009753000",
-          "Units": "NA",
-          "Legal": "WOODLAND PARK #2 BLK   2 LT  12A G:1628",
-          "Valuation": "35990",
-          "formatted_address": "3205 Wyoming Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19118590000001",
-          "lng": "-149.9164015"
-        }
+        "Permit": "R19-2848",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3205 WYOMING, Anchorage, Alaska",
+        "Parcel": "1009753000",
+        "Units": "NA",
+        "Legal": "WOODLAND PARK #2 BLK   2 LT  12A G:1628",
+        "Valuation": "35990",
+        "formatted_address": "3205 Wyoming Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -4277,21 +3645,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2937",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "5701 YUKON CHARLIE LOOP, Anchorage, Alaska",
-          "Parcel": "1131215000",
-          "Units": "NA",
-          "Legal": "WESTPARK ADDN 5 BLK  9 LT  15  G:2223",
-          "Valuation": "4000",
-          "formatted_address": "5701 Yukon Charlie Loop, Anchorage, AK 99502, USA",
-          "lat": "61.1498159",
-          "lng": "-149.9854547"
-        }
+        "Permit": "R19-2937",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "5701 YUKON CHARLIE LOOP, Anchorage, Alaska",
+        "Parcel": "1131215000",
+        "Units": "NA",
+        "Legal": "WESTPARK ADDN 5 BLK  9 LT  15  G:2223",
+        "Valuation": "4000",
+        "formatted_address": "5701 Yukon Charlie Loop, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -4304,21 +3668,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2943",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "4010 WORONZOF, Anchorage, Alaska",
-          "Parcel": "1005359000",
-          "Units": "NA",
-          "Legal": "TURNAGAIN WEST BLK  2 LT  26  G:1625",
-          "Valuation": "15760",
-          "formatted_address": "4010 Woronzof Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19371919999999",
-          "lng": "-149.9600436"
-        }
+        "Permit": "R19-2943",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "4010 WORONZOF, Anchorage, Alaska",
+        "Parcel": "1005359000",
+        "Units": "NA",
+        "Legal": "TURNAGAIN WEST BLK  2 LT  26  G:1625",
+        "Valuation": "15760",
+        "formatted_address": "4010 Woronzof Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -4331,21 +3691,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2946",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "6912 CUTTY SARK, Anchorage, Alaska",
-          "Parcel": "1108207000",
-          "Units": "NA",
-          "Legal": "SCOTTISH HILLS BLK  1 LT  30  G:2125",
-          "Valuation": "11880",
-          "formatted_address": "6912 Cutty Sark St, Anchorage, AK 99502, USA",
-          "lat": "61.15794829999999",
-          "lng": "-149.9582376"
-        }
+        "Permit": "R19-2946",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "6912 CUTTY SARK, Anchorage, Alaska",
+        "Parcel": "1108207000",
+        "Units": "NA",
+        "Legal": "SCOTTISH HILLS BLK  1 LT  30  G:2125",
+        "Valuation": "11880",
+        "formatted_address": "6912 Cutty Sark St, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -4358,21 +3714,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2947",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "9750 CHENEGA, Anchorage, Alaska",
-          "Parcel": "4102205000",
-          "Units": "NA",
-          "Legal": "TUXEDNI PARK BLK  1 LT  13  G:2042",
-          "Valuation": "15760",
-          "formatted_address": "9750 Chenega Dr, Anchorage, AK 99507, USA",
-          "lat": "61.16375189999999",
-          "lng": "-149.7032439"
-        }
+        "Permit": "R19-2947",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "9750 CHENEGA, Anchorage, Alaska",
+        "Parcel": "4102205000",
+        "Units": "NA",
+        "Legal": "TUXEDNI PARK BLK  1 LT  13  G:2042",
+        "Valuation": "15760",
+        "formatted_address": "9750 Chenega Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -4385,21 +3737,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2966",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1628 WOODCUTTER COURT, Anchorage, Alaska",
-          "Parcel": "927355075",
-          "Units": "NA",
-          "Legal": "FYFE BLK   3 LT   2 WOODED ACRES G:1933",
-          "Valuation": "12000",
-          "formatted_address": "1628 Woodcutter Ct, Anchorage, AK 99507, USA",
-          "lat": "61.1685063",
-          "lng": "-149.8517779"
-        }
+        "Permit": "R19-2966",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1628 WOODCUTTER COURT, Anchorage, Alaska",
+        "Parcel": "927355075",
+        "Units": "NA",
+        "Legal": "FYFE BLK   3 LT   2 WOODED ACRES G:1933",
+        "Valuation": "12000",
+        "formatted_address": "1628 Woodcutter Ct, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -4412,21 +3760,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2967",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2271 BELMONT, Anchorage, Alaska",
-          "Parcel": "117323000",
-          "Units": "NA",
-          "Legal": "HUNTINGTON PARK #5A BLK  5 LT  22  G:1528",
-          "Valuation": "15000",
-          "formatted_address": "2271 Belmont Dr, Anchorage, AK 99517, USA",
-          "lat": "61.2001948",
-          "lng": "-149.9207019"
-        }
+        "Permit": "R19-2967",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2271 BELMONT, Anchorage, Alaska",
+        "Parcel": "117323000",
+        "Units": "NA",
+        "Legal": "HUNTINGTON PARK #5A BLK  5 LT  22  G:1528",
+        "Valuation": "15000",
+        "formatted_address": "2271 Belmont Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -4439,21 +3783,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-3031",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "MIDNIGHT SUN SOLAR LLC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3756 HENDERSON, Anchorage, Alaska",
-          "Parcel": "1408139000",
-          "Units": "NA",
-          "Legal": "GATEWAY BLK  2 LT   2  G:2135",
-          "Valuation": "7500",
-          "formatted_address": "3756 Henderson Loop, Anchorage, AK 99507, USA",
-          "lat": "61.15661530000001",
-          "lng": "-149.8131622"
-        }
+        "Permit": "R19-3031",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "MIDNIGHT SUN SOLAR LLC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3756 HENDERSON, Anchorage, Alaska",
+        "Parcel": "1408139000",
+        "Units": "NA",
+        "Legal": "GATEWAY BLK  2 LT   2  G:2135",
+        "Valuation": "7500",
+        "formatted_address": "3756 Henderson Loop, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -4466,21 +3806,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-3033",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "N 1848 SALEM, Anchorage, Alaska",
-          "Parcel": "911140000",
-          "Units": "NA",
-          "Legal": "UNIVERSITY PARK #1 BLK  2 LT  15  G:1733",
-          "Valuation": "14990",
-          "formatted_address": "1848 N Salem Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1838679",
-          "lng": "-149.8460206"
-        }
+        "Permit": "R19-3033",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "N 1848 SALEM, Anchorage, Alaska",
+        "Parcel": "911140000",
+        "Units": "NA",
+        "Legal": "UNIVERSITY PARK #1 BLK  2 LT  15  G:1733",
+        "Valuation": "14990",
+        "formatted_address": "1848 N Salem Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -4493,21 +3829,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-3034",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "8521 PIONEER, Anchorage, Alaska",
-          "Parcel": "723305000",
-          "Units": "NA",
-          "Legal": "CHUGACH FOOTHILLS #1 BLK  5 LT  39  G:1741",
-          "Valuation": "28788",
-          "formatted_address": "8521 Pioneer Dr, Anchorage, AK 99504, USA",
-          "lat": "61.1836254",
-          "lng": "-149.7234994"
-        }
+        "Permit": "R19-3034",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "8521 PIONEER, Anchorage, Alaska",
+        "Parcel": "723305000",
+        "Units": "NA",
+        "Legal": "CHUGACH FOOTHILLS #1 BLK  5 LT  39  G:1741",
+        "Valuation": "28788",
+        "formatted_address": "8521 Pioneer Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -4520,21 +3852,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-3098",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1411 ATKINSON, Anchorage, Alaska",
-          "Parcel": "616742000",
-          "Units": "NA",
-          "Legal": "NUNAKA VALLEY BLK  C LT  13  G:1438",
-          "Valuation": "10799",
-          "formatted_address": "1411 Atkinson Dr, Anchorage, AK 99504, USA",
-          "lat": "61.2082966",
-          "lng": "-149.7665015"
-        }
+        "Permit": "R19-3098",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1411 ATKINSON, Anchorage, Alaska",
+        "Parcel": "616742000",
+        "Units": "NA",
+        "Legal": "NUNAKA VALLEY BLK  C LT  13  G:1438",
+        "Valuation": "10799",
+        "formatted_address": "1411 Atkinson Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -4547,21 +3875,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "X19-1271",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3737 COVENTRY, Anchorage, Alaska",
-          "Parcel": "1423335000",
-          "Units": "NA",
-          "Legal": "WINCHESTER HEIGHTS BLK  4 LT  11  G:2235",
-          "Valuation": "20030",
-          "formatted_address": "3737 Coventry Dr, Anchorage, AK 99507, USA",
-          "lat": "61.14565049999999",
-          "lng": "-149.8132932"
-        }
+        "Permit": "X19-1271",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3737 COVENTRY, Anchorage, Alaska",
+        "Parcel": "1423335000",
+        "Units": "NA",
+        "Legal": "WINCHESTER HEIGHTS BLK  4 LT  11  G:2235",
+        "Valuation": "20030",
+        "formatted_address": "3737 Coventry Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -4574,21 +3898,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-1263",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "4/30/17",
-          "year": "2017",
-          "Address": "5201 TAURUS CIRCLE, Anchorage, Alaska",
-          "Parcel": "2009231000",
-          "Units": "1",
-          "Legal": "LOMA ESTATES BLK   3 LT   2  G:3337",
-          "Valuation": "10653",
-          "formatted_address": "5201 Taurus Cir, Anchorage, AK 99516, USA",
-          "lat": "61.0683794",
-          "lng": "-149.783229"
-        }
+        "Permit": "R17-1263",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "4/30/17",
+        "year": "2017",
+        "Address": "5201 TAURUS CIRCLE, Anchorage, Alaska",
+        "Parcel": "2009231000",
+        "Units": "1",
+        "Legal": "LOMA ESTATES BLK   3 LT   2  G:3337",
+        "Valuation": "10653",
+        "formatted_address": "5201 Taurus Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -4601,21 +3921,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-1264",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "4/30/17",
-          "year": "2017",
-          "Address": "8212 RACE CIRCLE, Anchorage, Alaska",
-          "Parcel": "711647000",
-          "Units": "1",
-          "Legal": "CHUGACH FOOTHILLS #9 BLK   9 LT  45A  G:1741",
-          "Valuation": "6200",
-          "formatted_address": "8212 Race Cir, Anchorage, AK 99504, USA",
-          "lat": "61.1858105",
-          "lng": "-149.7267031"
-        }
+        "Permit": "R17-1264",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "4/30/17",
+        "year": "2017",
+        "Address": "8212 RACE CIRCLE, Anchorage, Alaska",
+        "Parcel": "711647000",
+        "Units": "1",
+        "Legal": "CHUGACH FOOTHILLS #9 BLK   9 LT  45A  G:1741",
+        "Valuation": "6200",
+        "formatted_address": "8212 Race Cir, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -4628,21 +3944,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-1293",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "4/30/17",
-          "year": "2017",
-          "Address": "E 5542 97TH, Anchorage, Alaska",
-          "Parcel": "1507213000",
-          "Units": "1",
-          "Legal": "SUMMIT ESTATES BLK   2 LT   6  G:2437",
-          "Valuation": "13992",
-          "formatted_address": "5542 E 97th Ave, Anchorage, AK 99507, USA",
-          "lat": "61.1324095",
-          "lng": "-149.7783229"
-        }
+        "Permit": "R17-1293",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "4/30/17",
+        "year": "2017",
+        "Address": "E 5542 97TH, Anchorage, Alaska",
+        "Parcel": "1507213000",
+        "Units": "1",
+        "Legal": "SUMMIT ESTATES BLK   2 LT   6  G:2437",
+        "Valuation": "13992",
+        "formatted_address": "5542 E 97th Ave, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -4655,21 +3967,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-1294",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "4/30/17",
-          "year": "2017",
-          "Address": "1407 INLET PLACE, Anchorage, Alaska",
-          "Parcel": "109344000",
-          "Units": "1",
-          "Legal": "SOUTH ADDITION BLK  35C LT   7A  G:1429",
-          "Valuation": "21000",
-          "formatted_address": "1407 Inlet Pl, Anchorage, AK 99501, USA",
-          "lat": "61.20865569999999",
-          "lng": "-149.9042234"
-        }
+        "Permit": "R17-1294",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "4/30/17",
+        "year": "2017",
+        "Address": "1407 INLET PLACE, Anchorage, Alaska",
+        "Parcel": "109344000",
+        "Units": "1",
+        "Legal": "SOUTH ADDITION BLK  35C LT   7A  G:1429",
+        "Valuation": "21000",
+        "formatted_address": "1407 Inlet Pl, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -4682,21 +3990,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C17-1493",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "5/31/17",
-          "year": "2017",
-          "Address": "2301 SPENARD, Anchorage, Alaska",
-          "Parcel": "116455000",
-          "Units": "0",
-          "Legal": "ROMIG PARK BLK   4 LT   9A  G:1529",
-          "Valuation": "26800",
-          "formatted_address": "2301 Spenard Rd, Anchorage, AK 99503, USA",
-          "lat": "61.19998260000001",
-          "lng": "-149.9061404"
-        }
+        "Permit": "C17-1493",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "5/31/17",
+        "year": "2017",
+        "Address": "2301 SPENARD, Anchorage, Alaska",
+        "Parcel": "116455000",
+        "Units": "0",
+        "Legal": "ROMIG PARK BLK   4 LT   9A  G:1529",
+        "Valuation": "26800",
+        "formatted_address": "2301 Spenard Rd, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -4709,21 +4013,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-1474",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/17",
-          "year": "2017",
-          "Address": "1957 WILDWOOD, Anchorage, Alaska",
-          "Parcel": "114343000",
-          "Units": "0",
-          "Legal": "LINGO LT   1A  G:1428",
-          "Valuation": "17502",
-          "formatted_address": "1957 Wildwood Ln, Anchorage, AK 99517, USA",
-          "lat": "61.2033179",
-          "lng": "-149.9207956"
-        }
+        "Permit": "R17-1474",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/17",
+        "year": "2017",
+        "Address": "1957 WILDWOOD, Anchorage, Alaska",
+        "Parcel": "114343000",
+        "Units": "0",
+        "Legal": "LINGO LT   1A  G:1428",
+        "Valuation": "17502",
+        "formatted_address": "1957 Wildwood Ln, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -4736,21 +4036,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-1475",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/17",
-          "year": "2017",
-          "Address": "12800 HUFFMAN, Anchorage, Alaska",
-          "Parcel": "1808149000",
-          "Units": "0",
-          "Legal": "HUFFMAN HILLS NORTH BLK   2 LT   6  G:2833",
-          "Valuation": "12710",
-          "formatted_address": "12800 Huffman Rd, Anchorage, AK 99516, USA",
-          "lat": "61.10860700000001",
-          "lng": "-149.74453690000001"
-        }
+        "Permit": "R17-1475",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/17",
+        "year": "2017",
+        "Address": "12800 HUFFMAN, Anchorage, Alaska",
+        "Parcel": "1808149000",
+        "Units": "0",
+        "Legal": "HUFFMAN HILLS NORTH BLK   2 LT   6  G:2833",
+        "Valuation": "12710",
+        "formatted_address": "12800 Huffman Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -4763,21 +4059,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-1476",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/17",
-          "year": "2017",
-          "Address": "10611 TAHNEETA, Anchorage, Alaska",
-          "Parcel": "1511250000",
-          "Units": "0",
-          "Legal": "SHELL #1 LT   1A  G:2536",
-          "Valuation": "12170",
-          "formatted_address": "10611 Tahneeta Dr, Anchorage, AK 99507, USA",
-          "lat": "61.12449030000001",
-          "lng": "-149.7989562"
-        }
+        "Permit": "R17-1476",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/17",
+        "year": "2017",
+        "Address": "10611 TAHNEETA, Anchorage, Alaska",
+        "Parcel": "1511250000",
+        "Units": "0",
+        "Legal": "SHELL #1 LT   1A  G:2536",
+        "Valuation": "12170",
+        "formatted_address": "10611 Tahneeta Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -4790,21 +4082,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-1573",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "5/31/17",
-          "year": "2017",
-          "Address": "10641 ELIES, Anchorage, Alaska",
-          "Parcel": "1513427000",
-          "Units": "0",
-          "Legal": "LAKEWOOD HILLS #4 BLK   1 LT   5  G:2540",
-          "Valuation": "16128",
-          "formatted_address": "10641 Elies Dr, Anchorage, AK 99507, USA",
-          "lat": "61.12442919999999",
-          "lng": "-149.7383847"
-        }
+        "Permit": "R17-1573",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "5/31/17",
+        "year": "2017",
+        "Address": "10641 ELIES, Anchorage, Alaska",
+        "Parcel": "1513427000",
+        "Units": "0",
+        "Legal": "LAKEWOOD HILLS #4 BLK   1 LT   5  G:2540",
+        "Valuation": "16128",
+        "formatted_address": "10641 Elies Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -4817,21 +4105,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C17-1590",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "LIME SOLAR LLC",
-          "Date": "6/30/17",
-          "year": "2017",
-          "Address": "6637 ARCTIC SPUR, Anchorage, Alaska",
-          "Parcel": "1208111000",
-          "Units": "0",
-          "Legal": "ARCTIC INDUSTRIAL #2 BLK   1 LT  11  G:2029",
-          "Valuation": "60000",
-          "formatted_address": "6637 Arctic Spur Rd, Anchorage, AK 99518, USA",
-          "lat": "61.1602755",
-          "lng": "-149.8951757"
-        }
+        "Permit": "C17-1590",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "LIME SOLAR LLC",
+        "Date": "6/30/17",
+        "year": "2017",
+        "Address": "6637 ARCTIC SPUR, Anchorage, Alaska",
+        "Parcel": "1208111000",
+        "Units": "0",
+        "Legal": "ARCTIC INDUSTRIAL #2 BLK   1 LT  11  G:2029",
+        "Valuation": "60000",
+        "formatted_address": "6637 Arctic Spur Rd, Anchorage, AK 99518, USA"
       }
     },
     {
@@ -4844,21 +4128,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-1664",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/17",
-          "year": "2017",
-          "Address": "17053 ARIES COURT, Anchorage, Alaska",
-          "Parcel": "2009127000",
-          "Units": "0",
-          "Legal": "SUSITNA VIEW ESTATES BLK   3 LT  11  G:3336",
-          "Valuation": "16128",
-          "formatted_address": "17053 Aries Ct, Anchorage, AK 99516, USA",
-          "lat": "61.0657167",
-          "lng": "-149.7906093"
-        }
+        "Permit": "R17-1664",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/17",
+        "year": "2017",
+        "Address": "17053 ARIES COURT, Anchorage, Alaska",
+        "Parcel": "2009127000",
+        "Units": "0",
+        "Legal": "SUSITNA VIEW ESTATES BLK   3 LT  11  G:3336",
+        "Valuation": "16128",
+        "formatted_address": "17053 Aries Ct, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -4871,21 +4151,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-1880",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "7/31/17",
-          "year": "2017",
-          "Address": "10001 HAMPTON, Anchorage, Alaska",
-          "Parcel": "1513465000",
-          "Units": "0",
-          "Legal": "HAMPTON HILLS #1 BLK   2 LT  14  G:2540",
-          "Valuation": "13720",
-          "formatted_address": "10001 Hampton Dr, Anchorage, AK 99507, USA",
-          "lat": "61.13011110000001",
-          "lng": "-149.7395554"
-        }
+        "Permit": "R17-1880",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "7/31/17",
+        "year": "2017",
+        "Address": "10001 HAMPTON, Anchorage, Alaska",
+        "Parcel": "1513465000",
+        "Units": "0",
+        "Legal": "HAMPTON HILLS #1 BLK   2 LT  14  G:2540",
+        "Valuation": "13720",
+        "formatted_address": "10001 Hampton Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -4898,21 +4174,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-2117",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "8/31/17",
-          "year": "2017",
-          "Address": "16001 WIND SONG, Anchorage, Alaska",
-          "Parcel": "2004290000",
-          "Units": "0",
-          "Legal": "PTARMIGAN ROOST BLK   3 LT   5  G:3238",
-          "Valuation": "10725",
-          "formatted_address": "16001 Wind Song Dr, Anchorage, AK 99516, USA",
-          "lat": "61.07580249999999",
-          "lng": "-149.7626801"
-        }
+        "Permit": "R17-2117",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "8/31/17",
+        "year": "2017",
+        "Address": "16001 WIND SONG, Anchorage, Alaska",
+        "Parcel": "2004290000",
+        "Units": "0",
+        "Legal": "PTARMIGAN ROOST BLK   3 LT   5  G:3238",
+        "Valuation": "10725",
+        "formatted_address": "16001 Wind Song Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -4925,21 +4197,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-2124",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/17",
-          "year": "2017",
-          "Address": "3544 DEBARR, Anchorage, Alaska",
-          "Parcel": "412301000",
-          "Units": "0",
-          "Legal": "GRANDVIEW GARDENS BLK   9 LT  10  G:1435",
-          "Valuation": "14110",
-          "formatted_address": "3544 DeBarr Rd, Anchorage, AK 99508, USA",
-          "lat": "61.2095209",
-          "lng": "-149.8146562"
-        }
+        "Permit": "R17-2124",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/17",
+        "year": "2017",
+        "Address": "3544 DEBARR, Anchorage, Alaska",
+        "Parcel": "412301000",
+        "Units": "0",
+        "Legal": "GRANDVIEW GARDENS BLK   9 LT  10  G:1435",
+        "Valuation": "14110",
+        "formatted_address": "3544 DeBarr Rd, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -4952,21 +4220,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-2251",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "8/31/17",
-          "year": "2017",
-          "Address": "10610 PACER, Anchorage, Alaska",
-          "Parcel": "1511242000",
-          "Units": "0",
-          "Legal": "O'MALLEY HEIGHTS LT   3A  G:2536",
-          "Valuation": "11800",
-          "formatted_address": "10610 Pacer Pl, Anchorage, AK 99507, USA",
-          "lat": "61.1246519",
-          "lng": "-149.7982114"
-        }
+        "Permit": "R17-2251",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "8/31/17",
+        "year": "2017",
+        "Address": "10610 PACER, Anchorage, Alaska",
+        "Parcel": "1511242000",
+        "Units": "0",
+        "Legal": "O'MALLEY HEIGHTS LT   3A  G:2536",
+        "Valuation": "11800",
+        "formatted_address": "10610 Pacer Pl, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -4979,21 +4243,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-2268",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "LIME SOLAR LLC",
-          "Date": "8/31/17",
-          "year": "2017",
-          "Address": "2421 MAYLEN, Anchorage, Alaska",
-          "Parcel": "1801163000",
-          "Units": "0",
-          "Legal": "HUFFMAN HILLS NORTH #2 BLK   1 LT  19  G:2833",
-          "Valuation": "14000",
-          "formatted_address": "2421 Maylen Cir, Anchorage, AK 99516, USA",
-          "lat": "61.10572990000001",
-          "lng": "-149.8365397"
-        }
+        "Permit": "R17-2268",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "LIME SOLAR LLC",
+        "Date": "8/31/17",
+        "year": "2017",
+        "Address": "2421 MAYLEN, Anchorage, Alaska",
+        "Parcel": "1801163000",
+        "Units": "0",
+        "Legal": "HUFFMAN HILLS NORTH #2 BLK   1 LT  19  G:2833",
+        "Valuation": "14000",
+        "formatted_address": "2421 Maylen Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -5006,21 +4266,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C17-2004",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "10/31/17",
-          "year": "2017",
-          "Address": "3800 ALUMNI DRIVE, Anchorage, Alaska",
-          "Parcel": "421101000",
-          "Units": "0",
-          "Legal": "T13N R3W SEC 28 NE4NE4  G:1635",
-          "Valuation": "9900",
-          "formatted_address": "Administrative/Humanities Building, 3800 Alumni Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1918458",
-          "lng": "-149.8145754"
-        }
+        "Permit": "C17-2004",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "10/31/17",
+        "year": "2017",
+        "Address": "3800 ALUMNI DRIVE, Anchorage, Alaska",
+        "Parcel": "421101000",
+        "Units": "0",
+        "Legal": "T13N R3W SEC 28 NE4NE4  G:1635",
+        "Valuation": "9900",
+        "formatted_address": "Administrative/Humanities Building, 3800 Alumni Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5033,21 +4289,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R17-2669",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "11/30/17",
-          "year": "2017",
-          "Address": "1709 KEPNER, Anchorage, Alaska",
-          "Parcel": "623210000",
-          "Units": "0",
-          "Legal": "NUNAKA VALLEY BLK   W LT   3  G:1438",
-          "Valuation": "13224",
-          "formatted_address": "1709 Kepner Dr, Anchorage, AK 99504, USA",
-          "lat": "61.2043236",
-          "lng": "-149.7689512"
-        }
+        "Permit": "R17-2669",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "11/30/17",
+        "year": "2017",
+        "Address": "1709 KEPNER, Anchorage, Alaska",
+        "Parcel": "623210000",
+        "Units": "0",
+        "Legal": "NUNAKA VALLEY BLK   W LT   3  G:1438",
+        "Valuation": "13224",
+        "formatted_address": "1709 Kepner Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -5060,21 +4312,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1116",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "2/28/18",
-          "year": "2018",
-          "Address": "2024 WILDWOOD, Anchorage, Alaska",
-          "Parcel": "114202000",
-          "Units": "0",
-          "Legal": "LINGO LT  30  G:1428",
-          "Valuation": "11580",
-          "formatted_address": "2024 Wildwood Ln, Anchorage, AK 99517, USA",
-          "lat": "61.20352020000001",
-          "lng": "-149.9235914"
-        }
+        "Permit": "R18-1116",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "2/28/18",
+        "year": "2018",
+        "Address": "2024 WILDWOOD, Anchorage, Alaska",
+        "Parcel": "114202000",
+        "Units": "0",
+        "Legal": "LINGO LT  30  G:1428",
+        "Valuation": "11580",
+        "formatted_address": "2024 Wildwood Ln, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -5087,21 +4335,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1126",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "3/31/18",
-          "year": "2018",
-          "Address": "10501 LONE TREE, Anchorage, Alaska",
-          "Parcel": "1532219000",
-          "Units": "0",
-          "Legal": "VALLI VUE ESTATES #2 BLK   3 LT  44  G:2538",
-          "Valuation": "16500",
-          "formatted_address": "10501 Lone Tree Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1257713",
-          "lng": "-149.7628334"
-        }
+        "Permit": "R18-1126",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "3/31/18",
+        "year": "2018",
+        "Address": "10501 LONE TREE, Anchorage, Alaska",
+        "Parcel": "1532219000",
+        "Units": "0",
+        "Legal": "VALLI VUE ESTATES #2 BLK   3 LT  44  G:2538",
+        "Valuation": "16500",
+        "formatted_address": "10501 Lone Tree Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -5114,21 +4358,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1162",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "3/31/18",
-          "year": "2018",
-          "Address": "342 ORCHID CIRCLE, Anchorage, Alaska",
-          "Parcel": "1804161000",
-          "Units": "0",
-          "Legal": "BOTANICAL PARK ESTATES LT  14  G:2830",
-          "Valuation": "24000",
-          "formatted_address": "342 Orchid Cir, Anchorage, AK 99515, USA",
-          "lat": "61.10721340000001",
-          "lng": "-149.8856305"
-        }
+        "Permit": "R18-1162",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "3/31/18",
+        "year": "2018",
+        "Address": "342 ORCHID CIRCLE, Anchorage, Alaska",
+        "Parcel": "1804161000",
+        "Units": "0",
+        "Legal": "BOTANICAL PARK ESTATES LT  14  G:2830",
+        "Valuation": "24000",
+        "formatted_address": "342 Orchid Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -5141,21 +4381,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1163",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "3/31/18",
-          "year": "2018",
-          "Address": "E 5165 172ND, Anchorage, Alaska",
-          "Parcel": "2009246000",
-          "Units": "0",
-          "Legal": "LOMA ESTATES BLK   2 LT   5  G:3337",
-          "Valuation": "24634",
-          "formatted_address": "5165 E 172nd Ave, Anchorage, AK 99516, USA",
-          "lat": "61.0655756",
-          "lng": "-149.7861558"
-        }
+        "Permit": "R18-1163",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "3/31/18",
+        "year": "2018",
+        "Address": "E 5165 172ND, Anchorage, Alaska",
+        "Parcel": "2009246000",
+        "Units": "0",
+        "Legal": "LOMA ESTATES BLK   2 LT   5  G:3337",
+        "Valuation": "24634",
+        "formatted_address": "5165 E 172nd Ave, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -5168,21 +4404,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1301",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "4/30/18",
-          "year": "2018",
-          "Address": "16800 RANSOM RIDGE, Anchorage, Alaska",
-          "Parcel": "2009215000",
-          "Units": "0",
-          "Legal": "RANSOM RIDGE LT   5  G:3337",
-          "Valuation": "11328",
-          "formatted_address": "16800 Ransom Ridge Rd, Anchorage, AK 99516, USA",
-          "lat": "61.06816010000001",
-          "lng": "-149.7776424"
-        }
+        "Permit": "R18-1301",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "4/30/18",
+        "year": "2018",
+        "Address": "16800 RANSOM RIDGE, Anchorage, Alaska",
+        "Parcel": "2009215000",
+        "Units": "0",
+        "Legal": "RANSOM RIDGE LT   5  G:3337",
+        "Valuation": "11328",
+        "formatted_address": "16800 Ransom Ridge Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -5195,21 +4427,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1416",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "4/30/18",
-          "year": "2018",
-          "Address": "E 2710 20TH, Anchorage, Alaska",
-          "Parcel": "415322000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   7 LT  22  G:1534",
-          "Valuation": "9882",
-          "formatted_address": "2710 E 20th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.20232490000001",
-          "lng": "-149.8314976"
-        }
+        "Permit": "R18-1416",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "4/30/18",
+        "year": "2018",
+        "Address": "E 2710 20TH, Anchorage, Alaska",
+        "Parcel": "415322000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   7 LT  22  G:1534",
+        "Valuation": "9882",
+        "formatted_address": "2710 E 20th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5222,21 +4450,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1428",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/18",
-          "year": "2018",
-          "Address": "6700 MACBETH DRIVE, Anchorage, Alaska",
-          "Parcel": "1551110000",
-          "Units": "0",
-          "Legal": "MACBETH BLK   2 LT   2  G:2639",
-          "Valuation": "18000",
-          "formatted_address": "6700 MacBeth Dr, Anchorage, AK 99516, USA",
-          "lat": "61.12037909999999",
-          "lng": "-149.7562917"
-        }
+        "Permit": "R18-1428",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/18",
+        "year": "2018",
+        "Address": "6700 MACBETH DRIVE, Anchorage, Alaska",
+        "Parcel": "1551110000",
+        "Units": "0",
+        "Legal": "MACBETH BLK   2 LT   2  G:2639",
+        "Valuation": "18000",
+        "formatted_address": "6700 MacBeth Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -5249,21 +4473,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1496",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "5/31/18",
-          "year": "2018",
-          "Address": "2814 ALDER, Anchorage, Alaska",
-          "Parcel": "415421000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   7 LT  46  G:1534",
-          "Valuation": "10974",
-          "formatted_address": "2814 Alder Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1998039",
-          "lng": "-149.8278173"
-        }
+        "Permit": "R18-1496",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "5/31/18",
+        "year": "2018",
+        "Address": "2814 ALDER, Anchorage, Alaska",
+        "Parcel": "415421000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   7 LT  46  G:1534",
+        "Valuation": "10974",
+        "formatted_address": "2814 Alder Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5276,21 +4496,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1578",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "5/31/18",
-          "year": "2018",
-          "Address": "E 3543 19TH, Anchorage, Alaska",
-          "Parcel": "413240000",
-          "Units": "0",
-          "Legal": "THUNDERBIRD TERRACE #1 BLK   7 LT  26  G:1435",
-          "Valuation": "6195",
-          "formatted_address": "3543 E 19th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.2041304",
-          "lng": "-149.8144706"
-        }
+        "Permit": "R18-1578",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "5/31/18",
+        "year": "2018",
+        "Address": "E 3543 19TH, Anchorage, Alaska",
+        "Parcel": "413240000",
+        "Units": "0",
+        "Legal": "THUNDERBIRD TERRACE #1 BLK   7 LT  26  G:1435",
+        "Valuation": "6195",
+        "formatted_address": "3543 E 19th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5303,21 +4519,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1583",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "5/31/18",
-          "year": "2018",
-          "Address": "E 2430 16TH, Anchorage, Alaska",
-          "Parcel": "414651000",
-          "Units": "0",
-          "Legal": "CITY VIEW #1 BLK   1 LT  24  G:1434",
-          "Valuation": "15665",
-          "formatted_address": "2430 E 16th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.2059373",
-          "lng": "-149.8353346"
-        }
+        "Permit": "R18-1583",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "5/31/18",
+        "year": "2018",
+        "Address": "E 2430 16TH, Anchorage, Alaska",
+        "Parcel": "414651000",
+        "Units": "0",
+        "Legal": "CITY VIEW #1 BLK   1 LT  24  G:1434",
+        "Valuation": "15665",
+        "formatted_address": "2430 E 16th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5330,21 +4542,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1584",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "5/31/18",
-          "year": "2018",
-          "Address": "E 2318 20TH, Anchorage, Alaska",
-          "Parcel": "415203000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   6 LT   4  G:1534",
-          "Valuation": "9590",
-          "formatted_address": "2318 E 20th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.20229699999999",
-          "lng": "-149.8373404"
-        }
+        "Permit": "R18-1584",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "5/31/18",
+        "year": "2018",
+        "Address": "E 2318 20TH, Anchorage, Alaska",
+        "Parcel": "415203000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   6 LT   4  G:1534",
+        "Valuation": "9590",
+        "formatted_address": "2318 E 20th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5357,21 +4565,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1585",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "5/31/18",
-          "year": "2018",
-          "Address": "2712 KOBUK, Anchorage, Alaska",
-          "Parcel": "414354000",
-          "Units": "0",
-          "Legal": "CITY VIEW #3 BLK   6 LT  30  G:1434",
-          "Valuation": "15665",
-          "formatted_address": "2712 Kobuk Ct, Anchorage, AK 99508, USA",
-          "lat": "61.2054191",
-          "lng": "-149.8303467"
-        }
+        "Permit": "R18-1585",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "5/31/18",
+        "year": "2018",
+        "Address": "2712 KOBUK, Anchorage, Alaska",
+        "Parcel": "414354000",
+        "Units": "0",
+        "Legal": "CITY VIEW #3 BLK   6 LT  30  G:1434",
+        "Valuation": "15665",
+        "formatted_address": "2712 Kobuk Ct, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5384,21 +4588,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1635",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "LIME SOLAR LLC",
-          "Date": "5/31/18",
-          "year": "2018",
-          "Address": "7730 EASTBROOK, Anchorage, Alaska",
-          "Parcel": "635548000",
-          "Units": "0",
-          "Legal": "EASTBROOK BLK   1 LT  48  G:1540",
-          "Valuation": "4800",
-          "formatted_address": "7730 Eastbrook Dr, Anchorage, AK 99504, USA",
-          "lat": "61.1995332",
-          "lng": "-149.7373248"
-        }
+        "Permit": "R18-1635",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "LIME SOLAR LLC",
+        "Date": "5/31/18",
+        "year": "2018",
+        "Address": "7730 EASTBROOK, Anchorage, Alaska",
+        "Parcel": "635548000",
+        "Units": "0",
+        "Legal": "EASTBROOK BLK   1 LT  48  G:1540",
+        "Valuation": "4800",
+        "formatted_address": "7730 Eastbrook Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -5411,21 +4611,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1703",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "5/31/18",
-          "year": "2018",
-          "Address": "2136 ALDER DRIVE, Anchorage, Alaska",
-          "Parcel": "415410000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   7 LT  35  G:1534",
-          "Valuation": "10383",
-          "formatted_address": "2136 Alder Dr, Anchorage, AK 99508, USA",
-          "lat": "61.20116590000001",
-          "lng": "-149.8292703"
-        }
+        "Permit": "R18-1703",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "5/31/18",
+        "year": "2018",
+        "Address": "2136 ALDER DRIVE, Anchorage, Alaska",
+        "Parcel": "415410000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   7 LT  35  G:1534",
+        "Valuation": "10383",
+        "formatted_address": "2136 Alder Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5438,21 +4634,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1704",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "5/31/18",
-          "year": "2018",
-          "Address": "3039 ALDER DRIVE, Anchorage, Alaska",
-          "Parcel": "415506000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   7 LT  54 P-254 G:1534",
-          "Valuation": "10974",
-          "formatted_address": "3039 Alder Dr, Anchorage, AK 99508, USA",
-          "lat": "61.199911",
-          "lng": "-149.8269159"
-        }
+        "Permit": "R18-1704",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "5/31/18",
+        "year": "2018",
+        "Address": "3039 ALDER DRIVE, Anchorage, Alaska",
+        "Parcel": "415506000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   7 LT  54 P-254 G:1534",
+        "Valuation": "10974",
+        "formatted_address": "3039 Alder Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5465,21 +4657,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1705",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "5/31/18",
-          "year": "2018",
-          "Address": "2410 OAK DRIVE DRIVE, Anchorage, Alaska",
-          "Parcel": "415304000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   7 LT   4 P-254 G:1534",
-          "Valuation": "7906",
-          "formatted_address": "2410 Oak Dr, Anchorage, AK 99508, USA",
-          "lat": "61.201452",
-          "lng": "-149.8364012"
-        }
+        "Permit": "R18-1705",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "5/31/18",
+        "year": "2018",
+        "Address": "2410 OAK DRIVE DRIVE, Anchorage, Alaska",
+        "Parcel": "415304000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   7 LT   4 P-254 G:1534",
+        "Valuation": "7906",
+        "formatted_address": "2410 Oak Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5492,21 +4680,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C18-1697",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "540 MUMFORD, Anchorage, Alaska",
-          "Parcel": "404418000",
-          "Units": "0",
-          "Legal": "MOUNTAIN VIEW BLK  17 LT   2 N3 E2  G:1135",
-          "Valuation": "16000",
-          "formatted_address": "540 Mumford St, Anchorage, AK 99508, USA",
-          "lat": "61.22861380000001",
-          "lng": "-149.8145664"
-        }
+        "Permit": "C18-1697",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "540 MUMFORD, Anchorage, Alaska",
+        "Parcel": "404418000",
+        "Units": "0",
+        "Legal": "MOUNTAIN VIEW BLK  17 LT   2 N3 E2  G:1135",
+        "Valuation": "16000",
+        "formatted_address": "540 Mumford St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5519,21 +4703,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1827",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "E 2300 16TH, Anchorage, Alaska",
-          "Parcel": "414645000",
-          "Units": "0",
-          "Legal": "CITY VIEW #1 BLK   1 LT  18  G:1434",
-          "Valuation": "11174",
-          "formatted_address": "2300 E 16th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.2057897",
-          "lng": "-149.8374036"
-        }
+        "Permit": "R18-1827",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "E 2300 16TH, Anchorage, Alaska",
+        "Parcel": "414645000",
+        "Units": "0",
+        "Legal": "CITY VIEW #1 BLK   1 LT  18  G:1434",
+        "Valuation": "11174",
+        "formatted_address": "2300 E 16th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5546,21 +4726,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1828",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "1518 AIRPORT HEIGHTS, Anchorage, Alaska",
-          "Parcel": "411242000",
-          "Units": "0",
-          "Legal": "SAXTON BLK   4 LT  15  G:1434",
-          "Valuation": "10974",
-          "formatted_address": "1518 Airport Heights Dr, Anchorage, AK 99508, USA",
-          "lat": "61.20752090000001",
-          "lng": "-149.8238097"
-        }
+        "Permit": "R18-1828",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "1518 AIRPORT HEIGHTS, Anchorage, Alaska",
+        "Parcel": "411242000",
+        "Units": "0",
+        "Legal": "SAXTON BLK   4 LT  15  G:1434",
+        "Valuation": "10974",
+        "formatted_address": "1518 Airport Heights Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5573,21 +4749,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1832",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "E 2709 17TH, Anchorage, Alaska",
-          "Parcel": "414333000",
-          "Units": "0",
-          "Legal": "CITY VIEW #3 BLK   6 LT   7  G:1434",
-          "Valuation": "10974",
-          "formatted_address": "2709 E 17th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.2050248",
-          "lng": "-149.8316153"
-        }
+        "Permit": "R18-1832",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "E 2709 17TH, Anchorage, Alaska",
+        "Parcel": "414333000",
+        "Units": "0",
+        "Legal": "CITY VIEW #3 BLK   6 LT   7  G:1434",
+        "Valuation": "10974",
+        "formatted_address": "2709 E 17th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5600,21 +4772,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1835",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "E 2410 17TH, Anchorage, Alaska",
-          "Parcel": "414561000",
-          "Units": "0",
-          "Legal": "CITY VIEW #2 BLK   2 LT  13  G:1434",
-          "Valuation": "7906",
-          "formatted_address": "2410 E 17th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.2050515",
-          "lng": "-149.8362432"
-        }
+        "Permit": "R18-1835",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "E 2410 17TH, Anchorage, Alaska",
+        "Parcel": "414561000",
+        "Units": "0",
+        "Legal": "CITY VIEW #2 BLK   2 LT  13  G:1434",
+        "Valuation": "7906",
+        "formatted_address": "2410 E 17th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5627,21 +4795,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1836",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "2129 SUNRISE, Anchorage, Alaska",
-          "Parcel": "415518000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   7 LT  65  G:1534",
-          "Valuation": "7906",
-          "formatted_address": "2129 Sunrise Dr, Anchorage, AK 99508, USA",
-          "lat": "61.20129790000001",
-          "lng": "-149.8271071"
-        }
+        "Permit": "R18-1836",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "2129 SUNRISE, Anchorage, Alaska",
+        "Parcel": "415518000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   7 LT  65  G:1534",
+        "Valuation": "7906",
+        "formatted_address": "2129 Sunrise Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5654,21 +4818,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1837",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "E 2739 17TH, Anchorage, Alaska",
-          "Parcel": "414330000",
-          "Units": "0",
-          "Legal": "CITY VIEW #3 BLK   6 LT   4  G:1434",
-          "Valuation": "10974",
-          "formatted_address": "2739 E 17th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.205136",
-          "lng": "-149.8304254"
-        }
+        "Permit": "R18-1837",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "E 2739 17TH, Anchorage, Alaska",
+        "Parcel": "414330000",
+        "Units": "0",
+        "Legal": "CITY VIEW #3 BLK   6 LT   4  G:1434",
+        "Valuation": "10974",
+        "formatted_address": "2739 E 17th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5681,21 +4841,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1838",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "1406 SUNRISE, Anchorage, Alaska",
-          "Parcel": "412607000",
-          "Units": "0",
-          "Legal": "GRANDVIEW GARDENS BLK   2 LT  11B  G:1435",
-          "Valuation": "7145",
-          "formatted_address": "1406 Sunrise Dr, Anchorage, AK 99508, USA",
-          "lat": "61.2085577",
-          "lng": "-149.8201345"
-        }
+        "Permit": "R18-1838",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "1406 SUNRISE, Anchorage, Alaska",
+        "Parcel": "412607000",
+        "Units": "0",
+        "Legal": "GRANDVIEW GARDENS BLK   2 LT  11B  G:1435",
+        "Valuation": "7145",
+        "formatted_address": "1406 Sunrise Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5708,21 +4864,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1839",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "1820 LOGAN STREET, Anchorage, Alaska",
-          "Parcel": "414508000",
-          "Units": "0",
-          "Legal": "CITY VIEW #2 BLK   3 LT  22  G:1434",
-          "Valuation": "8006",
-          "formatted_address": "1820 Logan St, Anchorage, AK 99508, USA",
-          "lat": "61.20387709999999",
-          "lng": "-149.8339212"
-        }
+        "Permit": "R18-1839",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "1820 LOGAN STREET, Anchorage, Alaska",
+        "Parcel": "414508000",
+        "Units": "0",
+        "Legal": "CITY VIEW #2 BLK   3 LT  22  G:1434",
+        "Valuation": "8006",
+        "formatted_address": "1820 Logan St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5735,21 +4887,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1840",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "1820 TOKLAT, Anchorage, Alaska",
-          "Parcel": "414539000",
-          "Units": "0",
-          "Legal": "CITY VIEW #2 BLK   2 LT  22  G:1434",
-          "Valuation": "10974",
-          "formatted_address": "1820 Toklat St, Anchorage, AK 99508, USA",
-          "lat": "61.20387489999999",
-          "lng": "-149.8354354"
-        }
+        "Permit": "R18-1840",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "1820 TOKLAT, Anchorage, Alaska",
+        "Parcel": "414539000",
+        "Units": "0",
+        "Legal": "CITY VIEW #2 BLK   2 LT  22  G:1434",
+        "Valuation": "10974",
+        "formatted_address": "1820 Toklat St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5762,21 +4910,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1847",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "1517 BIRCHWOOD, Anchorage, Alaska",
-          "Parcel": "411223000",
-          "Units": "0",
-          "Legal": "SAXTON BLK   3 LT   2  G:1434",
-          "Valuation": "10430",
-          "formatted_address": "1517 Birchwood St, Anchorage, AK 99508, USA",
-          "lat": "61.2075274",
-          "lng": "-149.8268209"
-        }
+        "Permit": "R18-1847",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "1517 BIRCHWOOD, Anchorage, Alaska",
+        "Parcel": "411223000",
+        "Units": "0",
+        "Legal": "SAXTON BLK   3 LT   2  G:1434",
+        "Valuation": "10430",
+        "formatted_address": "1517 Birchwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5789,21 +4933,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1905",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "W 607 12TH, Anchorage, Alaska",
-          "Parcel": "214430000",
-          "Units": "0",
-          "Legal": "SOUTH ADDITION BLK  22A LT   6  G:1330",
-          "Valuation": "5000",
-          "formatted_address": "607 W 12th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2108393",
-          "lng": "-149.8939492"
-        }
+        "Permit": "R18-1905",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "W 607 12TH, Anchorage, Alaska",
+        "Parcel": "214430000",
+        "Units": "0",
+        "Legal": "SOUTH ADDITION BLK  22A LT   6  G:1330",
+        "Valuation": "5000",
+        "formatted_address": "607 W 12th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -5816,21 +4956,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1906",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "9770 ATELIER, Anchorage, Alaska",
-          "Parcel": "4102250000",
-          "Units": "0",
-          "Legal": "TUXEDNI PARK WEST BLK   1 LT  12  G:2042",
-          "Valuation": "20000",
-          "formatted_address": "9770 Atelier Dr, Anchorage, AK 99507, USA",
-          "lat": "61.16606359999999",
-          "lng": "-149.7132236"
-        }
+        "Permit": "R18-1906",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "9770 ATELIER, Anchorage, Alaska",
+        "Parcel": "4102250000",
+        "Units": "0",
+        "Legal": "TUXEDNI PARK WEST BLK   1 LT  12  G:2042",
+        "Valuation": "20000",
+        "formatted_address": "9770 Atelier Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -5843,21 +4979,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1907",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "1435 M, Anchorage, Alaska",
-          "Parcel": "109433000",
-          "Units": "0",
-          "Legal": "VIEW RIDGE (OF SOUTH ADDN) BLK  35B LT  13  G:1429",
-          "Valuation": "9000",
-          "formatted_address": "1435 M St, Anchorage, AK 99501, USA",
-          "lat": "61.2080717",
-          "lng": "-149.9058105"
-        }
+        "Permit": "R18-1907",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "1435 M, Anchorage, Alaska",
+        "Parcel": "109433000",
+        "Units": "0",
+        "Legal": "VIEW RIDGE (OF SOUTH ADDN) BLK  35B LT  13  G:1429",
+        "Valuation": "9000",
+        "formatted_address": "1435 M St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -5870,21 +5002,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1908",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "5703 BIG BEND, Anchorage, Alaska",
-          "Parcel": "1128181000",
-          "Units": "0",
-          "Legal": "WESTPARK ADDN 2C BLK   3 LT  32  G:2223",
-          "Valuation": "6500",
-          "formatted_address": "5703 Big Bend Loop, Anchorage, AK 99502, USA",
-          "lat": "61.1442697",
-          "lng": "-149.9853639"
-        }
+        "Permit": "R18-1908",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "5703 BIG BEND, Anchorage, Alaska",
+        "Parcel": "1128181000",
+        "Units": "0",
+        "Legal": "WESTPARK ADDN 2C BLK   3 LT  32  G:2223",
+        "Valuation": "6500",
+        "formatted_address": "5703 Big Bend Loop, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -5897,21 +5025,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1947",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "W 1104 11TH, Anchorage, Alaska",
-          "Parcel": "108339000",
-          "Units": "0",
-          "Legal": "SOUTH ADDITION BLK  25B LT   1  G:1329",
-          "Valuation": "11063",
-          "formatted_address": "1104 W 11th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2114923",
-          "lng": "-149.9040302"
-        }
+        "Permit": "R18-1947",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "W 1104 11TH, Anchorage, Alaska",
+        "Parcel": "108339000",
+        "Units": "0",
+        "Legal": "SOUTH ADDITION BLK  25B LT   1  G:1329",
+        "Valuation": "11063",
+        "formatted_address": "1104 W 11th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -5924,21 +5048,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1992",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "E 3154 18TH, Anchorage, Alaska",
-          "Parcel": "413153000",
-          "Units": "0",
-          "Legal": "THUNDERBIRD TERRACE #1 BLK   2 LT  11  G:1435",
-          "Valuation": "20986",
-          "formatted_address": "3154 E 18th Cir, Anchorage, AK 99508, USA",
-          "lat": "61.20444009999999",
-          "lng": "-149.821224"
-        }
+        "Permit": "R18-1992",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "E 3154 18TH, Anchorage, Alaska",
+        "Parcel": "413153000",
+        "Units": "0",
+        "Legal": "THUNDERBIRD TERRACE #1 BLK   2 LT  11  G:1435",
+        "Valuation": "20986",
+        "formatted_address": "3154 E 18th Cir, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5951,21 +5071,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1993",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "E 2400 16TH, Anchorage, Alaska",
-          "Parcel": "414648000",
-          "Units": "0",
-          "Legal": "CITY VIEW #1 BLK   1 LT  21  G:1434",
-          "Valuation": "12853",
-          "formatted_address": "2400 E 16th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.2059271",
-          "lng": "-149.8363568"
-        }
+        "Permit": "R18-1993",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "E 2400 16TH, Anchorage, Alaska",
+        "Parcel": "414648000",
+        "Units": "0",
+        "Legal": "CITY VIEW #1 BLK   1 LT  21  G:1434",
+        "Valuation": "12853",
+        "formatted_address": "2400 E 16th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -5978,21 +5094,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1995",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "1519 COLUMBINE, Anchorage, Alaska",
-          "Parcel": "412408000",
-          "Units": "0",
-          "Legal": "GRANDVIEW GARDENS BLK   8 LT  18  G:1435",
-          "Valuation": "15665",
-          "formatted_address": "1519 Columbine St, Anchorage, AK 99508, USA",
-          "lat": "61.2074159",
-          "lng": "-149.8173315"
-        }
+        "Permit": "R18-1995",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "1519 COLUMBINE, Anchorage, Alaska",
+        "Parcel": "412408000",
+        "Units": "0",
+        "Legal": "GRANDVIEW GARDENS BLK   8 LT  18  G:1435",
+        "Valuation": "15665",
+        "formatted_address": "1519 Columbine St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6005,21 +5117,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1996",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "1519 AIRPORT HEIGHTS, Anchorage, Alaska",
-          "Parcel": "412644000",
-          "Units": "0",
-          "Legal": "GRANDVIEW GARDENS BLK   4 LT   3  G:1435",
-          "Valuation": "10974",
-          "formatted_address": "1519 Airport Heights Dr, Anchorage, AK 99508, USA",
-          "lat": "61.207421",
-          "lng": "-149.8228956"
-        }
+        "Permit": "R18-1996",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "1519 AIRPORT HEIGHTS, Anchorage, Alaska",
+        "Parcel": "412644000",
+        "Units": "0",
+        "Legal": "GRANDVIEW GARDENS BLK   4 LT   3  G:1435",
+        "Valuation": "10974",
+        "formatted_address": "1519 Airport Heights Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6032,21 +5140,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1997",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "1830 ALDER, Anchorage, Alaska",
-          "Parcel": "414307000",
-          "Units": "0",
-          "Legal": "CITY VIEW #2 BLK   8 LT  18  G:1434",
-          "Valuation": "7906",
-          "formatted_address": "1830 Alder Dr, Anchorage, AK 99508, USA",
-          "lat": "61.2037005",
-          "lng": "-149.8293217"
-        }
+        "Permit": "R18-1997",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "1830 ALDER, Anchorage, Alaska",
+        "Parcel": "414307000",
+        "Units": "0",
+        "Legal": "CITY VIEW #2 BLK   8 LT  18  G:1434",
+        "Valuation": "7906",
+        "formatted_address": "1830 Alder Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6059,21 +5163,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-1999",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "6/30/18",
-          "year": "2018",
-          "Address": "2800 ALDER, Anchorage, Alaska",
-          "Parcel": "415419000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   7 LT  44  G:1534",
-          "Valuation": "15665",
-          "formatted_address": "2800 Alder Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1998845",
-          "lng": "-149.8285353"
-        }
+        "Permit": "R18-1999",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "6/30/18",
+        "year": "2018",
+        "Address": "2800 ALDER, Anchorage, Alaska",
+        "Parcel": "415419000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   7 LT  44  G:1534",
+        "Valuation": "15665",
+        "formatted_address": "2800 Alder Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6086,21 +5186,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2051",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "7/31/18",
-          "year": "2018",
-          "Address": "6250 CRANBERRY, Anchorage, Alaska",
-          "Parcel": "1205147000",
-          "Units": "0",
-          "Legal": "WILK LT   2B  G:2026",
-          "Valuation": "13990",
-          "formatted_address": "6250 Cranberry St, Anchorage, AK 99502, USA",
-          "lat": "61.1638689",
-          "lng": "-149.93745"
-        }
+        "Permit": "R18-2051",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "7/31/18",
+        "year": "2018",
+        "Address": "6250 CRANBERRY, Anchorage, Alaska",
+        "Parcel": "1205147000",
+        "Units": "0",
+        "Legal": "WILK LT   2B  G:2026",
+        "Valuation": "13990",
+        "formatted_address": "6250 Cranberry St, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -6113,21 +5209,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2052",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "7/31/18",
-          "year": "2018",
-          "Address": "6300 HABICHT, Anchorage, Alaska",
-          "Parcel": "607239000",
-          "Units": "0",
-          "Legal": "RAVENSBRUCH BLK   1 LT   6  G:1239",
-          "Valuation": "20637",
-          "formatted_address": "6300 Habicht Ct, Anchorage, AK 99504, USA",
-          "lat": "61.21759119999999",
-          "lng": "-149.7629306"
-        }
+        "Permit": "R18-2052",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "7/31/18",
+        "year": "2018",
+        "Address": "6300 HABICHT, Anchorage, Alaska",
+        "Parcel": "607239000",
+        "Units": "0",
+        "Legal": "RAVENSBRUCH BLK   1 LT   6  G:1239",
+        "Valuation": "20637",
+        "formatted_address": "6300 Habicht Ct, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -6140,21 +5232,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2085",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "7/31/18",
-          "year": "2018",
-          "Address": "1529 BIRCHWOOD, Anchorage, Alaska",
-          "Parcel": "411222000",
-          "Units": "0",
-          "Legal": "SAXTON BLK   3 LT   3  G:1434",
-          "Valuation": "13836",
-          "formatted_address": "1529 Birchwood St, Anchorage, AK 99508, USA",
-          "lat": "61.20735739999999",
-          "lng": "-149.8267441"
-        }
+        "Permit": "R18-2085",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "7/31/18",
+        "year": "2018",
+        "Address": "1529 BIRCHWOOD, Anchorage, Alaska",
+        "Parcel": "411222000",
+        "Units": "0",
+        "Legal": "SAXTON BLK   3 LT   3  G:1434",
+        "Valuation": "13836",
+        "formatted_address": "1529 Birchwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6167,21 +5255,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2086",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "7/31/18",
-          "year": "2018",
-          "Address": "2421 OAK DRIVE, Anchorage, Alaska",
-          "Parcel": "415215000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   6 LT  16  G:1534",
-          "Valuation": "15665",
-          "formatted_address": "2421 Oak Dr, Anchorage, AK 99508, USA",
-          "lat": "61.20186090000001",
-          "lng": "-149.8361789"
-        }
+        "Permit": "R18-2086",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "7/31/18",
+        "year": "2018",
+        "Address": "2421 OAK DRIVE, Anchorage, Alaska",
+        "Parcel": "415215000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   6 LT  16  G:1534",
+        "Valuation": "15665",
+        "formatted_address": "2421 Oak Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6194,21 +5278,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2087",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "7/31/18",
-          "year": "2018",
-          "Address": "1902 ALDER DRIVE, Anchorage, Alaska",
-          "Parcel": "414310000",
-          "Units": "0",
-          "Legal": "CITY VIEW #2 BLK   8 LT  21  G:1434",
-          "Valuation": "10974",
-          "formatted_address": "1902 Alder Dr, Anchorage, AK 99508, USA",
-          "lat": "61.2031883",
-          "lng": "-149.8293504"
-        }
+        "Permit": "R18-2087",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "7/31/18",
+        "year": "2018",
+        "Address": "1902 ALDER DRIVE, Anchorage, Alaska",
+        "Parcel": "414310000",
+        "Units": "0",
+        "Legal": "CITY VIEW #2 BLK   8 LT  21  G:1434",
+        "Valuation": "10974",
+        "formatted_address": "1902 Alder Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6221,21 +5301,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2088",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "7/31/18",
-          "year": "2018",
-          "Address": "2434 OAK DRIVE, Anchorage, Alaska",
-          "Parcel": "415307000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   7 LT   7 P-254 G:1534",
-          "Valuation": "14844",
-          "formatted_address": "2434 Oak Dr, Anchorage, AK 99508, USA",
-          "lat": "61.20162870000001",
-          "lng": "-149.8355917"
-        }
+        "Permit": "R18-2088",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "7/31/18",
+        "year": "2018",
+        "Address": "2434 OAK DRIVE, Anchorage, Alaska",
+        "Parcel": "415307000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   7 LT   7 P-254 G:1534",
+        "Valuation": "14844",
+        "formatted_address": "2434 Oak Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6248,21 +5324,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2089",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "7/31/18",
-          "year": "2018",
-          "Address": "E 2612 20TH, Anchorage, Alaska",
-          "Parcel": "415317000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   7 LT  17  G:1534",
-          "Valuation": "10974",
-          "formatted_address": "2612 E 20th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.2023088",
-          "lng": "-149.8330747"
-        }
+        "Permit": "R18-2089",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "7/31/18",
+        "year": "2018",
+        "Address": "E 2612 20TH, Anchorage, Alaska",
+        "Parcel": "415317000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   7 LT  17  G:1534",
+        "Valuation": "10974",
+        "formatted_address": "2612 E 20th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6275,21 +5347,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2090",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "7/31/18",
-          "year": "2018",
-          "Address": "3018 ALDER DRIVE, Anchorage, Alaska",
-          "Parcel": "415502000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   7 LT  73  G:1534",
-          "Valuation": "11075",
-          "formatted_address": "3018 Alder Dr, Anchorage, AK 99508, USA",
-          "lat": "61.199911",
-          "lng": "-149.8269159"
-        }
+        "Permit": "R18-2090",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "7/31/18",
+        "year": "2018",
+        "Address": "3018 ALDER DRIVE, Anchorage, Alaska",
+        "Parcel": "415502000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   7 LT  73  G:1534",
+        "Valuation": "11075",
+        "formatted_address": "3018 Alder Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6302,21 +5370,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2120",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "7/31/18",
-          "year": "2018",
-          "Address": "11009 NORTHFLEET, Anchorage, Alaska",
-          "Parcel": "1916307000",
-          "Units": "0",
-          "Legal": "LOOKOUT LANDING PHASE 3 BLK   2 LT  23  G:2627",
-          "Valuation": "15576",
-          "formatted_address": "11009 Northfleet Dr, Anchorage, AK 99515, USA",
-          "lat": "61.12079730000001",
-          "lng": "-149.9262756"
-        }
+        "Permit": "R18-2120",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "7/31/18",
+        "year": "2018",
+        "Address": "11009 NORTHFLEET, Anchorage, Alaska",
+        "Parcel": "1916307000",
+        "Units": "0",
+        "Legal": "LOOKOUT LANDING PHASE 3 BLK   2 LT  23  G:2627",
+        "Valuation": "15576",
+        "formatted_address": "11009 Northfleet Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -6329,21 +5393,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2121",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "7/31/18",
-          "year": "2018",
-          "Address": "230 PACIFIC VIEW, Anchorage, Alaska",
-          "Parcel": "1805120000",
-          "Units": "0",
-          "Legal": "OCEAN VIEW WEST #1 BLK   2 LT   4  G:2830",
-          "Valuation": "22066",
-          "formatted_address": "230 Pacific View Dr, Anchorage, AK 99515, USA",
-          "lat": "61.10451339999999",
-          "lng": "-149.8836542"
-        }
+        "Permit": "R18-2121",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "7/31/18",
+        "year": "2018",
+        "Address": "230 PACIFIC VIEW, Anchorage, Alaska",
+        "Parcel": "1805120000",
+        "Units": "0",
+        "Legal": "OCEAN VIEW WEST #1 BLK   2 LT   4  G:2830",
+        "Valuation": "22066",
+        "formatted_address": "230 Pacific View Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -6356,21 +5416,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C18-1989",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/18",
-          "year": "2018",
-          "Address": "502 EAST FIREWEED LANE, Anchorage, Alaska",
-          "Parcel": "901454000",
-          "Units": "0",
-          "Legal": "LAMPERT BLK   2 LT 33A  G:1531",
-          "Valuation": "46000",
-          "formatted_address": "502 E Fireweed Ln, Anchorage, AK 99503, USA",
-          "lat": "61.1973678",
-          "lng": "-149.873959"
-        }
+        "Permit": "C18-1989",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/18",
+        "year": "2018",
+        "Address": "502 EAST FIREWEED LANE, Anchorage, Alaska",
+        "Parcel": "901454000",
+        "Units": "0",
+        "Legal": "LAMPERT BLK   2 LT 33A  G:1531",
+        "Valuation": "46000",
+        "formatted_address": "502 E Fireweed Ln, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -6383,21 +5439,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2312",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/18",
-          "year": "2018",
-          "Address": "1801 TERREBONNE, Anchorage, Alaska",
-          "Parcel": "1255401000",
-          "Units": "0",
-          "Legal": "GRANDE TERRE BLK   1 LT   1  G:2228",
-          "Valuation": "19000",
-          "formatted_address": "1801 Terrebonne Loop, Anchorage, AK 99502, USA",
-          "lat": "61.1497292",
-          "lng": "-149.9149811"
-        }
+        "Permit": "R18-2312",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/18",
+        "year": "2018",
+        "Address": "1801 TERREBONNE, Anchorage, Alaska",
+        "Parcel": "1255401000",
+        "Units": "0",
+        "Legal": "GRANDE TERRE BLK   1 LT   1  G:2228",
+        "Valuation": "19000",
+        "formatted_address": "1801 Terrebonne Loop, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -6410,21 +5462,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2344",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "8/31/18",
-          "year": "2018",
-          "Address": "1564 BIRCHWOOD, Anchorage, Alaska",
-          "Parcel": "411214000",
-          "Units": "0",
-          "Legal": "SAXTON BLK  10 LT  11  G:1434",
-          "Valuation": "10140",
-          "formatted_address": "1564 Birchwood St, Anchorage, AK 99508, USA",
-          "lat": "61.2066603",
-          "lng": "-149.8276005"
-        }
+        "Permit": "R18-2344",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "8/31/18",
+        "year": "2018",
+        "Address": "1564 BIRCHWOOD, Anchorage, Alaska",
+        "Parcel": "411214000",
+        "Units": "0",
+        "Legal": "SAXTON BLK  10 LT  11  G:1434",
+        "Valuation": "10140",
+        "formatted_address": "1564 Birchwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6437,21 +5485,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2346",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "8/31/18",
-          "year": "2018",
-          "Address": "1923 KUSKOKWIM, Anchorage, Alaska",
-          "Parcel": "414315000",
-          "Units": "0",
-          "Legal": "CITY VIEW #2 BLK   8 LT  26  G:1434",
-          "Valuation": "7956",
-          "formatted_address": "1923 Kuskokwim St, Anchorage, AK 99508, USA",
-          "lat": "61.20285119999999",
-          "lng": "-149.830151"
-        }
+        "Permit": "R18-2346",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "8/31/18",
+        "year": "2018",
+        "Address": "1923 KUSKOKWIM, Anchorage, Alaska",
+        "Parcel": "414315000",
+        "Units": "0",
+        "Legal": "CITY VIEW #2 BLK   8 LT  26  G:1434",
+        "Valuation": "7956",
+        "formatted_address": "1923 Kuskokwim St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6464,21 +5508,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2384",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/18",
-          "year": "2018",
-          "Address": "121 WEST 11TH AVENUE, Anchorage, Alaska",
-          "Parcel": "214303000",
-          "Units": "0",
-          "Legal": "THIRD ADDITION BLK  12A LT  10  G:1330",
-          "Valuation": "17000",
-          "formatted_address": "121 W 11th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2118943",
-          "lng": "-149.884161"
-        }
+        "Permit": "R18-2384",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/18",
+        "year": "2018",
+        "Address": "121 WEST 11TH AVENUE, Anchorage, Alaska",
+        "Parcel": "214303000",
+        "Units": "0",
+        "Legal": "THIRD ADDITION BLK  12A LT  10  G:1330",
+        "Valuation": "17000",
+        "formatted_address": "121 W 11th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -6491,21 +5531,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2386",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/18",
-          "year": "2018",
-          "Address": "11921 WHISPERING SPRUCE, Anchorage, Alaska",
-          "Parcel": "1530120000",
-          "Units": "0",
-          "Legal": "SKY RANCH ESTATES #1 BLK   5 LT  18  G:2737",
-          "Valuation": "21000",
-          "formatted_address": "11921 Whispering Spruce Cir, Anchorage, AK 99516, USA",
-          "lat": "61.11292150000001",
-          "lng": "-149.7787787"
-        }
+        "Permit": "R18-2386",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/18",
+        "year": "2018",
+        "Address": "11921 WHISPERING SPRUCE, Anchorage, Alaska",
+        "Parcel": "1530120000",
+        "Units": "0",
+        "Legal": "SKY RANCH ESTATES #1 BLK   5 LT  18  G:2737",
+        "Valuation": "21000",
+        "formatted_address": "11921 Whispering Spruce Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -6518,21 +5554,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2477",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "8/31/18",
-          "year": "2018",
-          "Address": "16901 MOUNT MC KINLEY VIEW, Anchorage, Alaska",
-          "Parcel": "2010115000",
-          "Units": "0",
-          "Legal": "MT MCKINLEY VIEW ESTATES BLK   1 LT   1  G:3339",
-          "Valuation": "30680",
-          "formatted_address": "16901 Mt McKinley View Dr, Anchorage, AK 99516, USA",
-          "lat": "61.0677786",
-          "lng": "-149.7507853"
-        }
+        "Permit": "R18-2477",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "8/31/18",
+        "year": "2018",
+        "Address": "16901 MOUNT MC KINLEY VIEW, Anchorage, Alaska",
+        "Parcel": "2010115000",
+        "Units": "0",
+        "Legal": "MT MCKINLEY VIEW ESTATES BLK   1 LT   1  G:3339",
+        "Valuation": "30680",
+        "formatted_address": "16901 Mt McKinley View Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -6545,21 +5577,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2636",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "PIKE CHRISTOPHER J",
-          "Date": "9/30/18",
-          "year": "2018",
-          "Address": "1308 ANNAPOLIS, Anchorage, Alaska",
-          "Parcel": "323105000",
-          "Units": "0",
-          "Legal": "COLLEGE VILLAGE #10 BLK  28 LT   4  G:1632",
-          "Valuation": "4500",
-          "formatted_address": "1308 Annapolis Dr, Anchorage, AK 99508, USA",
-          "lat": "61.19179519999999",
-          "lng": "-149.8577995"
-        }
+        "Permit": "R18-2636",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "PIKE CHRISTOPHER J",
+        "Date": "9/30/18",
+        "year": "2018",
+        "Address": "1308 ANNAPOLIS, Anchorage, Alaska",
+        "Parcel": "323105000",
+        "Units": "0",
+        "Legal": "COLLEGE VILLAGE #10 BLK  28 LT   4  G:1632",
+        "Valuation": "4500",
+        "formatted_address": "1308 Annapolis Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6572,21 +5600,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2669",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "9/30/18",
-          "year": "2018",
-          "Address": "3650 FURROW CREEK, Anchorage, Alaska",
-          "Parcel": "1704210000",
-          "Units": "0",
-          "Legal": "MCMAHON BLK   3 LT  10  G:2835",
-          "Valuation": "20000",
-          "formatted_address": "3650 Furrow Creek Rd, Anchorage, AK 99516, USA",
-          "lat": "61.1056159",
-          "lng": "-149.8141669"
-        }
+        "Permit": "R18-2669",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "9/30/18",
+        "year": "2018",
+        "Address": "3650 FURROW CREEK, Anchorage, Alaska",
+        "Parcel": "1704210000",
+        "Units": "0",
+        "Legal": "MCMAHON BLK   3 LT  10  G:2835",
+        "Valuation": "20000",
+        "formatted_address": "3650 Furrow Creek Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -6599,21 +5623,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2689",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "9/30/18",
-          "year": "2018",
-          "Address": "W 2908 34TH, Anchorage, Alaska",
-          "Parcel": "1008206000",
-          "Units": "0",
-          "Legal": "TOPE LT   E  G:1627",
-          "Valuation": "11682",
-          "formatted_address": "2908 W 34th Ave, Anchorage, AK 99517, USA",
-          "lat": "61.18961409999999",
-          "lng": "-149.9377872"
-        }
+        "Permit": "R18-2689",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "9/30/18",
+        "year": "2018",
+        "Address": "W 2908 34TH, Anchorage, Alaska",
+        "Parcel": "1008206000",
+        "Units": "0",
+        "Legal": "TOPE LT   E  G:1627",
+        "Valuation": "11682",
+        "formatted_address": "2908 W 34th Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -6626,21 +5646,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2690",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "9/30/18",
-          "year": "2018",
-          "Address": "2561 LOVEJOY DRIVE, Anchorage, Alaska",
-          "Parcel": "416224000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   1 LT  18  G:1534",
-          "Valuation": "13216",
-          "formatted_address": "2561 Lovejoy Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1975728",
-          "lng": "-149.8345166"
-        }
+        "Permit": "R18-2690",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "9/30/18",
+        "year": "2018",
+        "Address": "2561 LOVEJOY DRIVE, Anchorage, Alaska",
+        "Parcel": "416224000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   1 LT  18  G:1534",
+        "Valuation": "13216",
+        "formatted_address": "2561 Lovejoy Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6653,21 +5669,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2743",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "10/31/18",
-          "year": "2018",
-          "Address": "1900 CHEROKEE WAY, Anchorage, Alaska",
-          "Parcel": "622349000",
-          "Units": "0",
-          "Legal": "INDIAN HILLS #3 BLK   4 LT  12  G:1439",
-          "Valuation": "15060",
-          "formatted_address": "1900 Cherokee Way, Anchorage, AK 99504, USA",
-          "lat": "61.2037298",
-          "lng": "-149.7533214"
-        }
+        "Permit": "R18-2743",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "10/31/18",
+        "year": "2018",
+        "Address": "1900 CHEROKEE WAY, Anchorage, Alaska",
+        "Parcel": "622349000",
+        "Units": "0",
+        "Legal": "INDIAN HILLS #3 BLK   4 LT  12  G:1439",
+        "Valuation": "15060",
+        "formatted_address": "1900 Cherokee Way, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -6680,21 +5692,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R18-2773",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ANCHORAGE SOLAR",
-          "Date": "10/31/18",
-          "year": "2018",
-          "Address": "3226 UPLAND, Anchorage, Alaska",
-          "Parcel": "705214000",
-          "Units": "0",
-          "Legal": "HILAND TERRACE BLK   1 LT   9  G:1640",
-          "Valuation": "25606",
-          "formatted_address": "3226 Upland Dr, Anchorage, AK 99504, USA",
-          "lat": "61.1908494",
-          "lng": "-149.7431966"
-        }
+        "Permit": "R18-2773",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ANCHORAGE SOLAR",
+        "Date": "10/31/18",
+        "year": "2018",
+        "Address": "3226 UPLAND, Anchorage, Alaska",
+        "Parcel": "705214000",
+        "Units": "0",
+        "Legal": "HILAND TERRACE BLK   1 LT   9  G:1640",
+        "Valuation": "25606",
+        "formatted_address": "3226 Upland Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -6707,21 +5715,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1043",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "1/31/20",
-          "year": "2020",
-          "Address": "2200 BELMONT, Anchorage, Alaska",
-          "Parcel": "117361000",
-          "Units": "0",
-          "Legal": "HUNTINGTON PARK #5A BLK   8 LT  20  G:1528",
-          "Valuation": "17000",
-          "formatted_address": "2200 Belmont Dr, Anchorage, AK 99517, USA",
-          "lat": "61.20046070000001",
-          "lng": "-149.922407"
-        }
+        "Permit": "R20-1043",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "1/31/20",
+        "year": "2020",
+        "Address": "2200 BELMONT, Anchorage, Alaska",
+        "Parcel": "117361000",
+        "Units": "0",
+        "Legal": "HUNTINGTON PARK #5A BLK   8 LT  20  G:1528",
+        "Valuation": "17000",
+        "formatted_address": "2200 Belmont Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -6734,21 +5738,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1044",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "1/31/20",
-          "year": "2020",
-          "Address": "W 2304 MARSTON, Anchorage, Alaska",
-          "Parcel": "119505000",
-          "Units": "0",
-          "Legal": "C L PLUMB LT   8  G:1526",
-          "Valuation": "15000",
-          "formatted_address": "2304 Marston Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1991249",
-          "lng": "-149.9544484"
-        }
+        "Permit": "R20-1044",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "1/31/20",
+        "year": "2020",
+        "Address": "W 2304 MARSTON, Anchorage, Alaska",
+        "Parcel": "119505000",
+        "Units": "0",
+        "Legal": "C L PLUMB LT   8  G:1526",
+        "Valuation": "15000",
+        "formatted_address": "2304 Marston Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -6761,21 +5761,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C20-1223",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "3/31/20",
-          "year": "2020",
-          "Address": "E 3521 TUDOR, Anchorage, Alaska",
-          "Parcel": "802182000",
-          "Units": "0",
-          "Legal": "ATHENIAN VILLAGE TR F-2A-2  G:1735",
-          "Valuation": "78000",
-          "formatted_address": "3521 E Tudor Rd, Anchorage, AK 99507, USA",
-          "lat": "61.1820672",
-          "lng": "-149.814158"
-        }
+        "Permit": "C20-1223",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "3/31/20",
+        "year": "2020",
+        "Address": "E 3521 TUDOR, Anchorage, Alaska",
+        "Parcel": "802182000",
+        "Units": "0",
+        "Legal": "ATHENIAN VILLAGE TR F-2A-2  G:1735",
+        "Valuation": "78000",
+        "formatted_address": "3521 E Tudor Rd, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -6788,21 +5784,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1209",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/20",
-          "year": "2020",
-          "Address": "7530 LABRADOR CIRCLE, Anchorage, Alaska",
-          "Parcel": "1107301000",
-          "Units": "0",
-          "Legal": "SPORTSMENS POINT #3 BLK   4 LT   4  G:2124",
-          "Valuation": "14747",
-          "formatted_address": "7530 Labrador Cir, Anchorage, AK 99502, USA",
-          "lat": "61.1524354",
-          "lng": "-149.9739249"
-        }
+        "Permit": "R20-1209",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/20",
+        "year": "2020",
+        "Address": "7530 LABRADOR CIRCLE, Anchorage, Alaska",
+        "Parcel": "1107301000",
+        "Units": "0",
+        "Legal": "SPORTSMENS POINT #3 BLK   4 LT   4  G:2124",
+        "Valuation": "14747",
+        "formatted_address": "7530 Labrador Cir, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -6815,21 +5807,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1210",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/20",
-          "year": "2020",
-          "Address": "8900 JUPITER, Anchorage, Alaska",
-          "Parcel": "1501231000",
-          "Units": "0",
-          "Legal": "ZODIAK MANOR ALASKA BLK   5 LT  18  G:2336",
-          "Valuation": "25487",
-          "formatted_address": "8900 Jupiter Dr, Anchorage, AK 99507, USA",
-          "lat": "61.14091329999999",
-          "lng": "-149.7973373"
-        }
+        "Permit": "R20-1210",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/20",
+        "year": "2020",
+        "Address": "8900 JUPITER, Anchorage, Alaska",
+        "Parcel": "1501231000",
+        "Units": "0",
+        "Legal": "ZODIAK MANOR ALASKA BLK   5 LT  18  G:2336",
+        "Valuation": "25487",
+        "formatted_address": "8900 Jupiter Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -6842,21 +5830,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1211",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/20",
-          "year": "2020",
-          "Address": "E 2306 74TH, Anchorage, Alaska",
-          "Parcel": "1413240000",
-          "Units": "0",
-          "Legal": "ALPINE VILLAGE BLK   5 LT  18A  G:2133",
-          "Valuation": "16877",
-          "formatted_address": "2306 E 74th Ave, Anchorage, AK 99507, USA",
-          "lat": "61.1535507",
-          "lng": "-149.8393451"
-        }
+        "Permit": "R20-1211",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/20",
+        "year": "2020",
+        "Address": "E 2306 74TH, Anchorage, Alaska",
+        "Parcel": "1413240000",
+        "Units": "0",
+        "Legal": "ALPINE VILLAGE BLK   5 LT  18A  G:2133",
+        "Valuation": "16877",
+        "formatted_address": "2306 E 74th Ave, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -6869,21 +5853,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1236",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "3/31/20",
-          "year": "2020",
-          "Address": "10830 KAMISHAK BAY, Anchorage, Alaska",
-          "Parcel": "1909103000",
-          "Units": "0",
-          "Legal": "BAYSHORE WEST #2 BLK   4 LT  23  G:2626",
-          "Valuation": "13000",
-          "formatted_address": "10830 Kamishak Bay Cir, Anchorage, AK 99515, USA",
-          "lat": "61.1229767",
-          "lng": "-149.9502782"
-        }
+        "Permit": "R20-1236",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "3/31/20",
+        "year": "2020",
+        "Address": "10830 KAMISHAK BAY, Anchorage, Alaska",
+        "Parcel": "1909103000",
+        "Units": "0",
+        "Legal": "BAYSHORE WEST #2 BLK   4 LT  23  G:2626",
+        "Valuation": "13000",
+        "formatted_address": "10830 Kamishak Bay Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -6896,21 +5876,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1237",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "3/31/20",
-          "year": "2020",
-          "Address": "2227 DOUGLAS DRIVE, Anchorage, Alaska",
-          "Parcel": "119122000",
-          "Units": "0",
-          "Legal": "PARK BLK   M LT  22  G:1526",
-          "Valuation": "18000",
-          "formatted_address": "2227 Douglas Dr, Anchorage, AK 99517, USA",
-          "lat": "61.199685",
-          "lng": "-149.9445783"
-        }
+        "Permit": "R20-1237",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "3/31/20",
+        "year": "2020",
+        "Address": "2227 DOUGLAS DRIVE, Anchorage, Alaska",
+        "Parcel": "119122000",
+        "Units": "0",
+        "Legal": "PARK BLK   M LT  22  G:1526",
+        "Valuation": "18000",
+        "formatted_address": "2227 Douglas Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -6923,21 +5899,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1238",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "3/31/20",
-          "year": "2020",
-          "Address": "3181 MARATHON CIRCLE, Anchorage, Alaska",
-          "Parcel": "1909223000",
-          "Units": "0",
-          "Legal": "BAYSHORE WEST #3 LT  31  G:2626",
-          "Valuation": "18000",
-          "formatted_address": "3181 Marathon Cir, Anchorage, AK 99515, USA",
-          "lat": "61.1224858",
-          "lng": "-149.9391302"
-        }
+        "Permit": "R20-1238",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "3/31/20",
+        "year": "2020",
+        "Address": "3181 MARATHON CIRCLE, Anchorage, Alaska",
+        "Parcel": "1909223000",
+        "Units": "0",
+        "Legal": "BAYSHORE WEST #3 LT  31  G:2626",
+        "Valuation": "18000",
+        "formatted_address": "3181 Marathon Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -6950,21 +5922,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1239",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "3/31/20",
-          "year": "2020",
-          "Address": "3800 WINTERSET, Anchorage, Alaska",
-          "Parcel": "910216000",
-          "Units": "0",
-          "Legal": "LAKE OTIS PARK BLK   C LT   6  G:1733",
-          "Valuation": "18000",
-          "formatted_address": "3800 Winterset Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1860296",
-          "lng": "-149.8523682"
-        }
+        "Permit": "R20-1239",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "3/31/20",
+        "year": "2020",
+        "Address": "3800 WINTERSET, Anchorage, Alaska",
+        "Parcel": "910216000",
+        "Units": "0",
+        "Legal": "LAKE OTIS PARK BLK   C LT   6  G:1733",
+        "Valuation": "18000",
+        "formatted_address": "3800 Winterset Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -6977,21 +5945,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1240",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "3/31/20",
-          "year": "2020",
-          "Address": "9102 SAHALEE, Anchorage, Alaska",
-          "Parcel": "1504416000",
-          "Units": "0",
-          "Legal": "SAHALEE BLK   1 LT  42  G:2336",
-          "Valuation": "13000",
-          "formatted_address": "9102 Sahalee Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1385877",
-          "lng": "-149.7911366"
-        }
+        "Permit": "R20-1240",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "3/31/20",
+        "year": "2020",
+        "Address": "9102 SAHALEE, Anchorage, Alaska",
+        "Parcel": "1504416000",
+        "Units": "0",
+        "Legal": "SAHALEE BLK   1 LT  42  G:2336",
+        "Valuation": "13000",
+        "formatted_address": "9102 Sahalee Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -7004,21 +5968,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1241",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/20",
-          "year": "2020",
-          "Address": "18222 WERRE, Anchorage, Alaska",
-          "Parcel": "5123247000",
-          "Units": "0",
-          "Legal": "T15N R1W SEC 18 LT 193B  G:1054",
-          "Valuation": "13888",
-          "formatted_address": "18222 Werre St, Chugiak, AK 99567, USA",
-          "lat": "61.38501580000001",
-          "lng": "-149.5267322"
-        }
+        "Permit": "R20-1241",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/20",
+        "year": "2020",
+        "Address": "18222 WERRE, Anchorage, Alaska",
+        "Parcel": "5123247000",
+        "Units": "0",
+        "Legal": "T15N R1W SEC 18 LT 193B  G:1054",
+        "Valuation": "13888",
+        "formatted_address": "18222 Werre St, Chugiak, AK 99567, USA"
       }
     },
     {
@@ -7031,21 +5991,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C20-1284",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "1801 O'MALLEY, Anchorage, Alaska",
-          "Parcel": "1606263000",
-          "Units": "0",
-          "Legal": "COMMODORE PARK TR   D-1  G:2533",
-          "Valuation": "39060",
-          "formatted_address": "1801 O'Malley Rd, Anchorage, AK 99507, USA",
-          "lat": "61.1240654",
-          "lng": "-149.8476803"
-        }
+        "Permit": "C20-1284",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "1801 O'MALLEY, Anchorage, Alaska",
+        "Parcel": "1606263000",
+        "Units": "0",
+        "Legal": "COMMODORE PARK TR   D-1  G:2533",
+        "Valuation": "39060",
+        "formatted_address": "1801 O'Malley Rd, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -7058,21 +6014,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C20-1330",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "6407 ARCTIC SPUR, Anchorage, Alaska",
-          "Parcel": "1202140000",
-          "Units": "0",
-          "Legal": "ARCTIC INDUSTRIAL #2 BLK   1 LTS  3 & 4  G:2029",
-          "Valuation": "87559.2",
-          "formatted_address": "6407 Arctic Spur Rd, Anchorage, AK 99518, USA",
-          "lat": "61.1629357",
-          "lng": "-149.8951159"
-        }
+        "Permit": "C20-1330",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "6407 ARCTIC SPUR, Anchorage, Alaska",
+        "Parcel": "1202140000",
+        "Units": "0",
+        "Legal": "ARCTIC INDUSTRIAL #2 BLK   1 LTS  3 & 4  G:2029",
+        "Valuation": "87559.2",
+        "formatted_address": "6407 Arctic Spur Rd, Anchorage, AK 99518, USA"
       }
     },
     {
@@ -7085,21 +6037,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1291",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "7436 BERN, Anchorage, Alaska",
-          "Parcel": "1413313000",
-          "Units": "0",
-          "Legal": "ALPINE VILLAGE BLK   4 LT   4  G:2133",
-          "Valuation": "14968",
-          "formatted_address": "7436 Bern St, Anchorage, AK 99507, USA",
-          "lat": "61.153057",
-          "lng": "-149.8403603"
-        }
+        "Permit": "R20-1291",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "7436 BERN, Anchorage, Alaska",
+        "Parcel": "1413313000",
+        "Units": "0",
+        "Legal": "ALPINE VILLAGE BLK   4 LT   4  G:2133",
+        "Valuation": "14968",
+        "formatted_address": "7436 Bern St, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -7112,21 +6060,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1292",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "14400 PRATOR, Anchorage, Alaska",
-          "Parcel": "1709301000",
-          "Units": "0",
-          "Legal": "ASPEN RIDGE BLK   1 LT   1  G:3039",
-          "Valuation": "23761",
-          "formatted_address": "14400 Prator St, Anchorage, AK 99516, USA",
-          "lat": "61.09027279999999",
-          "lng": "-149.7563969"
-        }
+        "Permit": "R20-1292",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "14400 PRATOR, Anchorage, Alaska",
+        "Parcel": "1709301000",
+        "Units": "0",
+        "Legal": "ASPEN RIDGE BLK   1 LT   1  G:3039",
+        "Valuation": "23761",
+        "formatted_address": "14400 Prator St, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -7139,21 +6083,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1294",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "4936 VIRGO, Anchorage, Alaska",
-          "Parcel": "2009137000",
-          "Units": "0",
-          "Legal": "SUSITNA VIEW ESTATES BLK   3 LT   6  G:3336",
-          "Valuation": "10958",
-          "formatted_address": "4936 Virgo Ave, Anchorage, AK 99516, USA",
-          "lat": "61.06775109999999",
-          "lng": "-149.7894643"
-        }
+        "Permit": "R20-1294",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "4936 VIRGO, Anchorage, Alaska",
+        "Parcel": "2009137000",
+        "Units": "0",
+        "Legal": "SUSITNA VIEW ESTATES BLK   3 LT   6  G:3336",
+        "Valuation": "10958",
+        "formatted_address": "4936 Virgo Ave, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -7166,21 +6106,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1307",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "MIDNIGHT SUN SOLAR LLC",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "E 3035 112TH, Anchorage, Alaska",
-          "Parcel": "1527150000",
-          "Units": "0",
-          "Legal": "PTARMIGAN VIEW ESTATES LT   2  G:2634",
-          "Valuation": "9765",
-          "formatted_address": "3035 E 112th Ave, Anchorage, AK 99516, USA",
-          "lat": "61.11965589999999",
-          "lng": "-149.8257016"
-        }
+        "Permit": "R20-1307",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "MIDNIGHT SUN SOLAR LLC",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "E 3035 112TH, Anchorage, Alaska",
+        "Parcel": "1527150000",
+        "Units": "0",
+        "Legal": "PTARMIGAN VIEW ESTATES LT   2  G:2634",
+        "Valuation": "9765",
+        "formatted_address": "3035 E 112th Ave, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -7193,21 +6129,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1338",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "8747 SAHALEE, Anchorage, Alaska",
-          "Parcel": "1501550000",
-          "Units": "0",
-          "Legal": "SAHALEE PHASE 2 BLK   2 LT  28  G:2336",
-          "Valuation": "20194",
-          "formatted_address": "8747 Sahalee Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1413399",
-          "lng": "-149.7898304"
-        }
+        "Permit": "R20-1338",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "8747 SAHALEE, Anchorage, Alaska",
+        "Parcel": "1501550000",
+        "Units": "0",
+        "Legal": "SAHALEE PHASE 2 BLK   2 LT  28  G:2336",
+        "Valuation": "20194",
+        "formatted_address": "8747 Sahalee Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -7220,21 +6152,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1339",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "8720 JUPITER, Anchorage, Alaska",
-          "Parcel": "1501228000",
-          "Units": "0",
-          "Legal": "ZODIAK MANOR ALASKA BLK   5 LT  21  G:2336",
-          "Valuation": "11996",
-          "formatted_address": "8720 Jupiter Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1416941",
-          "lng": "-149.7970031"
-        }
+        "Permit": "R20-1339",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "8720 JUPITER, Anchorage, Alaska",
+        "Parcel": "1501228000",
+        "Units": "0",
+        "Legal": "ZODIAK MANOR ALASKA BLK   5 LT  21  G:2336",
+        "Valuation": "11996",
+        "formatted_address": "8720 Jupiter Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -7247,21 +6175,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1340",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "6212 PROMINENCE POINTE, Anchorage, Alaska",
-          "Parcel": "2010277000",
-          "Units": "0",
-          "Legal": "PROMINENCE POINTE PH 7 BLK   4 LT   2  G:3338",
-          "Valuation": "17985",
-          "formatted_address": "6212 Prominence Pointe Dr, Anchorage, AK 99516, USA",
-          "lat": "61.0713582",
-          "lng": "-149.7654919"
-        }
+        "Permit": "R20-1340",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "6212 PROMINENCE POINTE, Anchorage, Alaska",
+        "Parcel": "2010277000",
+        "Units": "0",
+        "Legal": "PROMINENCE POINTE PH 7 BLK   4 LT   2  G:3338",
+        "Valuation": "17985",
+        "formatted_address": "6212 Prominence Pointe Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -7274,21 +6198,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1341",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "3789 HENDERSON, Anchorage, Alaska",
-          "Parcel": "1408151000",
-          "Units": "0",
-          "Legal": "GATEWAY BLK   1 LT  11  G:2135",
-          "Valuation": "6232",
-          "formatted_address": "3789 Henderson Loop, Anchorage, AK 99507, USA",
-          "lat": "61.15593859999999",
-          "lng": "-149.812286"
-        }
+        "Permit": "R20-1341",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "3789 HENDERSON, Anchorage, Alaska",
+        "Parcel": "1408151000",
+        "Units": "0",
+        "Legal": "GATEWAY BLK   1 LT  11  G:2135",
+        "Valuation": "6232",
+        "formatted_address": "3789 Henderson Loop, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -7301,21 +6221,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1342",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "20618 EDWARD STREET, Anchorage, Alaska",
-          "Parcel": "5111162000",
-          "Units": "0",
-          "Legal": "OUR MOUNTAIN BLK   2 LT   4  G:1361",
-          "Valuation": "13332",
-          "formatted_address": "Edward St, Anchorage, AK 99504, USA",
-          "lat": "61.2129907",
-          "lng": "-149.7634417"
-        }
+        "Permit": "R20-1342",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "20618 EDWARD STREET, Anchorage, Alaska",
+        "Parcel": "5111162000",
+        "Units": "0",
+        "Legal": "OUR MOUNTAIN BLK   2 LT   4  G:1361",
+        "Valuation": "13332",
+        "formatted_address": "Edward St, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -7328,21 +6244,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1394",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "3906 WESLEYAN, Anchorage, Alaska",
-          "Parcel": "515212000",
-          "Units": "0",
-          "Legal": "CASTLE HEIGHTS BLK   1 LT  12  G:1737",
-          "Valuation": "12502",
-          "formatted_address": "3906 Wesleyan Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1857155",
-          "lng": "-149.792807"
-        }
+        "Permit": "R20-1394",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "3906 WESLEYAN, Anchorage, Alaska",
+        "Parcel": "515212000",
+        "Units": "0",
+        "Legal": "CASTLE HEIGHTS BLK   1 LT  12  G:1737",
+        "Valuation": "12502",
+        "formatted_address": "3906 Wesleyan Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -7355,21 +6267,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1395",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "10540 WHITBY, Anchorage, Alaska",
-          "Parcel": "1140429000",
-          "Units": "0",
-          "Legal": "RESOLUTION POINTE PH 3 BLK  3A LT  26  G:2525",
-          "Valuation": "25100",
-          "formatted_address": "10540 Whitby Cir, Anchorage, AK 99515, USA",
-          "lat": "61.1250178",
-          "lng": "-149.9561537"
-        }
+        "Permit": "R20-1395",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "10540 WHITBY, Anchorage, Alaska",
+        "Parcel": "1140429000",
+        "Units": "0",
+        "Legal": "RESOLUTION POINTE PH 3 BLK  3A LT  26  G:2525",
+        "Valuation": "25100",
+        "formatted_address": "10540 Whitby Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -7382,21 +6290,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1396",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "2220 SHORE DRIVE, Anchorage, Alaska",
-          "Parcel": "1910172000",
-          "Units": "0",
-          "Legal": "SHORE CREST BLK   3 LT  16A  G:2728",
-          "Valuation": "24550",
-          "formatted_address": "2220 Shore Dr, Anchorage, AK 99515, USA",
-          "lat": "61.1112866",
-          "lng": "-149.9211318"
-        }
+        "Permit": "R20-1396",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "2220 SHORE DRIVE, Anchorage, Alaska",
+        "Parcel": "1910172000",
+        "Units": "0",
+        "Legal": "SHORE CREST BLK   3 LT  16A  G:2728",
+        "Valuation": "24550",
+        "formatted_address": "2220 Shore Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -7409,21 +6313,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1397",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "4859 PAVALOF, Anchorage, Alaska",
-          "Parcel": "920234000",
-          "Units": "0",
-          "Legal": "BANCROFT #2 BLK   3 LT  29  G:1832",
-          "Valuation": "18350",
-          "formatted_address": "4859 Pavalof St, Anchorage, AK 99507, USA",
-          "lat": "61.17638799999999",
-          "lng": "-149.8549611"
-        }
+        "Permit": "R20-1397",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "4859 PAVALOF, Anchorage, Alaska",
+        "Parcel": "920234000",
+        "Units": "0",
+        "Legal": "BANCROFT #2 BLK   3 LT  29  G:1832",
+        "Valuation": "18350",
+        "formatted_address": "4859 Pavalof St, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -7436,21 +6336,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1398",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "5224 EMMANUEL, Anchorage, Alaska",
-          "Parcel": "512229000",
-          "Units": "0",
-          "Legal": "COLLEGEGATE #6 BLK  13 LT  12  G:1637",
-          "Valuation": "19000",
-          "formatted_address": "5224 Emmanuel Ave, Anchorage, AK 99508, USA",
-          "lat": "61.1895104",
-          "lng": "-149.7844612"
-        }
+        "Permit": "R20-1398",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "5224 EMMANUEL, Anchorage, Alaska",
+        "Parcel": "512229000",
+        "Units": "0",
+        "Legal": "COLLEGEGATE #6 BLK  13 LT  12  G:1637",
+        "Valuation": "19000",
+        "formatted_address": "5224 Emmanuel Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -7463,21 +6359,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1399",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "12020 VICTOR, Anchorage, Alaska",
-          "Parcel": "1913102000",
-          "Units": "0",
-          "Legal": "SEASCAPE PH 1 BLK   1 LT   1  G:2727",
-          "Valuation": "22180",
-          "formatted_address": "12020 Victor Rd, Anchorage, AK 99515, USA",
-          "lat": "61.1116838",
-          "lng": "-149.9223423"
-        }
+        "Permit": "R20-1399",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "12020 VICTOR, Anchorage, Alaska",
+        "Parcel": "1913102000",
+        "Units": "0",
+        "Legal": "SEASCAPE PH 1 BLK   1 LT   1  G:2727",
+        "Valuation": "22180",
+        "formatted_address": "12020 Victor Rd, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -7490,21 +6382,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1400",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "4873 WESLEYAN, Anchorage, Alaska",
-          "Parcel": "515117000",
-          "Units": "0",
-          "Legal": "CASTLE HEIGHTS #1 BLK   6 LT   6  G:1737",
-          "Valuation": "16992",
-          "formatted_address": "4873 Wesleyan Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1851054",
-          "lng": "-149.7899159"
-        }
+        "Permit": "R20-1400",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "4873 WESLEYAN, Anchorage, Alaska",
+        "Parcel": "515117000",
+        "Units": "0",
+        "Legal": "CASTLE HEIGHTS #1 BLK   6 LT   6  G:1737",
+        "Valuation": "16992",
+        "formatted_address": "4873 Wesleyan Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -7517,21 +6405,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1401",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "3011 AMBER BAY, Anchorage, Alaska",
-          "Parcel": "1909168000",
-          "Units": "0",
-          "Legal": "BAYSHORE WEST #2 BLK   2 LT   7  G:2626",
-          "Valuation": "20880",
-          "formatted_address": "3011 Amber Bay Loop, Anchorage, AK 99515, USA",
-          "lat": "61.1222752",
-          "lng": "-149.9447046"
-        }
+        "Permit": "R20-1401",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "3011 AMBER BAY, Anchorage, Alaska",
+        "Parcel": "1909168000",
+        "Units": "0",
+        "Legal": "BAYSHORE WEST #2 BLK   2 LT   7  G:2626",
+        "Valuation": "20880",
+        "formatted_address": "3011 Amber Bay Loop, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -7544,21 +6428,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1402",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "3708 CHECKMATE, Anchorage, Alaska",
-          "Parcel": "515175000",
-          "Units": "0",
-          "Legal": "CASTLE HEIGHTS #4 BLK   7 LT  14  G:1737",
-          "Valuation": "12000",
-          "formatted_address": "3708 Checkmate Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1869646",
-          "lng": "-149.7853825"
-        }
+        "Permit": "R20-1402",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "3708 CHECKMATE, Anchorage, Alaska",
+        "Parcel": "515175000",
+        "Units": "0",
+        "Legal": "CASTLE HEIGHTS #4 BLK   7 LT  14  G:1737",
+        "Valuation": "12000",
+        "formatted_address": "3708 Checkmate Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -7571,21 +6451,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1403",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/20",
-          "year": "2020",
-          "Address": "8819 SAHALEE, Anchorage, Alaska",
-          "Parcel": "1504452000",
-          "Units": "0",
-          "Legal": "SAHALEE PHASE 2 BLK   2 LT  25  G:2336",
-          "Valuation": "16992",
-          "formatted_address": "8819 Sahalee Dr, Anchorage, AK 99507, USA",
-          "lat": "61.14069840000001",
-          "lng": "-149.7898857"
-        }
+        "Permit": "R20-1403",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/20",
+        "year": "2020",
+        "Address": "8819 SAHALEE, Anchorage, Alaska",
+        "Parcel": "1504452000",
+        "Units": "0",
+        "Legal": "SAHALEE PHASE 2 BLK   2 LT  25  G:2336",
+        "Valuation": "16992",
+        "formatted_address": "8819 Sahalee Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -7598,21 +6474,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1451",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "5140 NORGAARD ROAD, Anchorage, Alaska",
-          "Parcel": "1705124000",
-          "Units": "0",
-          "Legal": "T12N R3W SEC 27 LT  34  G:2937",
-          "Valuation": "16527",
-          "formatted_address": "5140 Norgaard Rd, Anchorage, AK 99516, USA",
-          "lat": "61.09641070000001",
-          "lng": "-149.7857855"
-        }
+        "Permit": "R20-1451",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "5140 NORGAARD ROAD, Anchorage, Alaska",
+        "Parcel": "1705124000",
+        "Units": "0",
+        "Legal": "T12N R3W SEC 27 LT  34  G:2937",
+        "Valuation": "16527",
+        "formatted_address": "5140 Norgaard Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -7625,21 +6497,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1452",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "6601 MARQUEZ CIRCLE, Anchorage, Alaska",
-          "Parcel": "1709312000",
-          "Units": "0",
-          "Legal": "PRATOR BLK  12A LT   4  G:3039",
-          "Valuation": "22102",
-          "formatted_address": "6601 Marquez Cir, Anchorage, AK 99516, USA",
-          "lat": "61.0922587",
-          "lng": "-149.7587284"
-        }
+        "Permit": "R20-1452",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "6601 MARQUEZ CIRCLE, Anchorage, Alaska",
+        "Parcel": "1709312000",
+        "Units": "0",
+        "Legal": "PRATOR BLK  12A LT   4  G:3039",
+        "Valuation": "22102",
+        "formatted_address": "6601 Marquez Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -7652,21 +6520,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1453",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "6401 ITALY CIRCLE, Anchorage, Alaska",
-          "Parcel": "2041131000",
-          "Units": "0",
-          "Legal": "PARADISE VALLEY BLK   4 LT  21A-1  G:3538",
-          "Valuation": "13892",
-          "formatted_address": "6401 Italy Cir, Anchorage, AK 99516, USA",
-          "lat": "61.0544041",
-          "lng": "-149.7628712"
-        }
+        "Permit": "R20-1453",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "6401 ITALY CIRCLE, Anchorage, Alaska",
+        "Parcel": "2041131000",
+        "Units": "0",
+        "Legal": "PARADISE VALLEY BLK   4 LT  21A-1  G:3538",
+        "Valuation": "13892",
+        "formatted_address": "6401 Italy Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -7679,21 +6543,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1454",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "E 3630 67TH, Anchorage, Alaska",
-          "Parcel": "1407152000",
-          "Units": "0",
-          "Legal": "CAMPBELL HEIGHTS BLK   2 LT   4B  G:2035",
-          "Valuation": "11996",
-          "formatted_address": "3630 E 67th Ave, Anchorage, AK 99507, USA",
-          "lat": "61.1598946",
-          "lng": "-149.8143089"
-        }
+        "Permit": "R20-1454",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "E 3630 67TH, Anchorage, Alaska",
+        "Parcel": "1407152000",
+        "Units": "0",
+        "Legal": "CAMPBELL HEIGHTS BLK   2 LT   4B  G:2035",
+        "Valuation": "11996",
+        "formatted_address": "3630 E 67th Ave, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -7706,21 +6566,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1455",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "8416 CORMORANT COVE, Anchorage, Alaska",
-          "Parcel": "1501612000",
-          "Units": "0",
-          "Legal": "SAHALEE PHASE 3 BLK   2 LT  44  G:2336",
-          "Valuation": "27033",
-          "formatted_address": "8416 Cormorant Cove Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1445692",
-          "lng": "-149.7910765"
-        }
+        "Permit": "R20-1455",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "8416 CORMORANT COVE, Anchorage, Alaska",
+        "Parcel": "1501612000",
+        "Units": "0",
+        "Legal": "SAHALEE PHASE 3 BLK   2 LT  44  G:2336",
+        "Valuation": "27033",
+        "formatted_address": "8416 Cormorant Cove Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -7733,21 +6589,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1459",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "11050 CANGE, Anchorage, Alaska",
-          "Parcel": "1527155000",
-          "Units": "0",
-          "Legal": "ALLEN LT   2  G:2634",
-          "Valuation": "19900",
-          "formatted_address": "11050 Cange St, Anchorage, AK 99516, USA",
-          "lat": "61.12062419999999",
-          "lng": "-149.8198929"
-        }
+        "Permit": "R20-1459",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "11050 CANGE, Anchorage, Alaska",
+        "Parcel": "1527155000",
+        "Units": "0",
+        "Legal": "ALLEN LT   2  G:2634",
+        "Valuation": "19900",
+        "formatted_address": "11050 Cange St, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -7760,21 +6612,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1460",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "2600 IVORY DRIVE, Anchorage, Alaska",
-          "Parcel": "1825101000",
-          "Units": "0",
-          "Legal": "MADDUX PARK LT   1  G:3034",
-          "Valuation": "22500",
-          "formatted_address": "2600 Ivory Dr, Anchorage, AK 99516, USA",
-          "lat": "61.09027589999999",
-          "lng": "-149.833491"
-        }
+        "Permit": "R20-1460",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "2600 IVORY DRIVE, Anchorage, Alaska",
+        "Parcel": "1825101000",
+        "Units": "0",
+        "Legal": "MADDUX PARK LT   1  G:3034",
+        "Valuation": "22500",
+        "formatted_address": "2600 Ivory Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -7787,21 +6635,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1539",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "7840 MARINO, Anchorage, Alaska",
-          "Parcel": "2055117000",
-          "Units": "0",
-          "Legal": "RABBIT CREEK VIEW & HEIGHTS BLK   4H LT   3A  G:3340",
-          "Valuation": "7156",
-          "formatted_address": "7840 Marino Dr, Anchorage, AK 99516, USA",
-          "lat": "61.071411",
-          "lng": "-149.735297"
-        }
+        "Permit": "R20-1539",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "7840 MARINO, Anchorage, Alaska",
+        "Parcel": "2055117000",
+        "Units": "0",
+        "Legal": "RABBIT CREEK VIEW & HEIGHTS BLK   4H LT   3A  G:3340",
+        "Valuation": "7156",
+        "formatted_address": "7840 Marino Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -7814,21 +6658,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1541",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "6700 FERNHILL, Anchorage, Alaska",
-          "Parcel": "1709131000",
-          "Units": "0",
-          "Legal": "PRATOR BLK   8 LT   4  G:3039",
-          "Valuation": "13551",
-          "formatted_address": "6700 Fernhill Ave, Anchorage, AK 99516, USA",
-          "lat": "61.08857080000001",
-          "lng": "-149.7564925"
-        }
+        "Permit": "R20-1541",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "6700 FERNHILL, Anchorage, Alaska",
+        "Parcel": "1709131000",
+        "Units": "0",
+        "Legal": "PRATOR BLK   8 LT   4  G:3039",
+        "Valuation": "13551",
+        "formatted_address": "6700 Fernhill Ave, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -7841,21 +6681,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1542",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "8605 SAHALEE, Anchorage, Alaska",
-          "Parcel": "1501557000",
-          "Units": "0",
-          "Legal": "SAHALEE PHASE 2 BLK   2 LT  54  G:2336",
-          "Valuation": "17394",
-          "formatted_address": "8605 Sahalee Dr, Anchorage, AK 99507, USA",
-          "lat": "61.14309890000001",
-          "lng": "-149.7918592"
-        }
+        "Permit": "R20-1542",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "8605 SAHALEE, Anchorage, Alaska",
+        "Parcel": "1501557000",
+        "Units": "0",
+        "Legal": "SAHALEE PHASE 2 BLK   2 LT  54  G:2336",
+        "Valuation": "17394",
+        "formatted_address": "8605 Sahalee Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -7868,21 +6704,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1543",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "8901 JUPITER, Anchorage, Alaska",
-          "Parcel": "1504242000",
-          "Units": "0",
-          "Legal": "ZODIAK MANOR ALASKA BLK   7 LT   5  G:2336",
-          "Valuation": "18255",
-          "formatted_address": "8901 Jupiter Dr, Anchorage, AK 99507, USA",
-          "lat": "61.14101340000001",
-          "lng": "-149.7962843"
-        }
+        "Permit": "R20-1543",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "8901 JUPITER, Anchorage, Alaska",
+        "Parcel": "1504242000",
+        "Units": "0",
+        "Legal": "ZODIAK MANOR ALASKA BLK   7 LT   5  G:2336",
+        "Valuation": "18255",
+        "formatted_address": "8901 Jupiter Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -7895,21 +6727,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1545",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "14600 JOANNE CIRCLE, Anchorage, Alaska",
-          "Parcel": "1709247000",
-          "Units": "0",
-          "Legal": "MELINDA VIEW ESTATES LT   4A  G:3038",
-          "Valuation": "12275",
-          "formatted_address": "14600 Joanne Cir, Anchorage, AK 99516, USA",
-          "lat": "61.08909079999999",
-          "lng": "-149.7694251"
-        }
+        "Permit": "R20-1545",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "14600 JOANNE CIRCLE, Anchorage, Alaska",
+        "Parcel": "1709247000",
+        "Units": "0",
+        "Legal": "MELINDA VIEW ESTATES LT   4A  G:3038",
+        "Valuation": "12275",
+        "formatted_address": "14600 Joanne Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -7922,21 +6750,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1653",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "4957 WESLEYAN, Anchorage, Alaska",
-          "Parcel": "515152000",
-          "Units": "0",
-          "Legal": "CASTLE HEIGHTS #2 BLK   6 LT  12  G:1737",
-          "Valuation": "20000",
-          "formatted_address": "4957 Wesleyan Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1858769",
-          "lng": "-149.7887486"
-        }
+        "Permit": "R20-1653",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "4957 WESLEYAN, Anchorage, Alaska",
+        "Parcel": "515152000",
+        "Units": "0",
+        "Legal": "CASTLE HEIGHTS #2 BLK   6 LT  12  G:1737",
+        "Valuation": "20000",
+        "formatted_address": "4957 Wesleyan Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -7949,21 +6773,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1654",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "1650 VASHON, Anchorage, Alaska",
-          "Parcel": "1911527000",
-          "Units": "0",
-          "Legal": "PIONEER WEST LT  27  G:2728",
-          "Valuation": "22000",
-          "formatted_address": "1650 Vashon Cir, Anchorage, AK 99515, USA",
-          "lat": "61.11471640000001",
-          "lng": "-149.9108629"
-        }
+        "Permit": "R20-1654",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "1650 VASHON, Anchorage, Alaska",
+        "Parcel": "1911527000",
+        "Units": "0",
+        "Legal": "PIONEER WEST LT  27  G:2728",
+        "Valuation": "22000",
+        "formatted_address": "1650 Vashon Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -7976,21 +6796,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1656",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "14200 JARVI, Anchorage, Alaska",
-          "Parcel": "1820437000",
-          "Units": "0",
-          "Legal": "SUNSET HILLS WEST BLK   3 LT 13A  G:3033",
-          "Valuation": "22000",
-          "formatted_address": "14200 Jarvi Dr, Anchorage, AK 99515, USA",
-          "lat": "61.0925345",
-          "lng": "-149.8483076"
-        }
+        "Permit": "R20-1656",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "14200 JARVI, Anchorage, Alaska",
+        "Parcel": "1820437000",
+        "Units": "0",
+        "Legal": "SUNSET HILLS WEST BLK   3 LT 13A  G:3033",
+        "Valuation": "22000",
+        "formatted_address": "14200 Jarvi Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -8003,21 +6819,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1657",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "3219 WESLEYAN, Anchorage, Alaska",
-          "Parcel": "512103000",
-          "Units": "0",
-          "Legal": "COLLEGEGATE BLK   2 LT   6  G:1637",
-          "Valuation": "13000",
-          "formatted_address": "3219 Wesleyan Dr, Anchorage, AK 99508, USA",
-          "lat": "61.19135600000001",
-          "lng": "-149.7911472"
-        }
+        "Permit": "R20-1657",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "3219 WESLEYAN, Anchorage, Alaska",
+        "Parcel": "512103000",
+        "Units": "0",
+        "Legal": "COLLEGEGATE BLK   2 LT   6  G:1637",
+        "Valuation": "13000",
+        "formatted_address": "3219 Wesleyan Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -8030,21 +6842,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1658",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "N 1935 SALEM, Anchorage, Alaska",
-          "Parcel": "911120000",
-          "Units": "0",
-          "Legal": "UNIVERSITY PARK #1 BLK   1 LT  20  G:1733",
-          "Valuation": "13000",
-          "formatted_address": "1935 N Salem Dr, Anchorage, AK 99508, USA",
-          "lat": "61.184243",
-          "lng": "-149.8444689"
-        }
+        "Permit": "R20-1658",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "N 1935 SALEM, Anchorage, Alaska",
+        "Parcel": "911120000",
+        "Units": "0",
+        "Legal": "UNIVERSITY PARK #1 BLK   1 LT  20  G:1733",
+        "Valuation": "13000",
+        "formatted_address": "1935 N Salem Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -8057,21 +6865,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1659",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "2501 TURNAGAIN, Anchorage, Alaska",
-          "Parcel": "123638000",
-          "Units": "0",
-          "Legal": "TURNAGAIN HOMES BLK   H LT  12  G:1527",
-          "Valuation": "8500",
-          "formatted_address": "2501 Turnagain Pkwy, Anchorage, AK 99517, USA",
-          "lat": "61.19787139999999",
-          "lng": "-149.9427194"
-        }
+        "Permit": "R20-1659",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "2501 TURNAGAIN, Anchorage, Alaska",
+        "Parcel": "123638000",
+        "Units": "0",
+        "Legal": "TURNAGAIN HOMES BLK   H LT  12  G:1527",
+        "Valuation": "8500",
+        "formatted_address": "2501 Turnagain Pkwy, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -8084,21 +6888,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1660",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "10554 WHITBY, Anchorage, Alaska",
-          "Parcel": "1140430000",
-          "Units": "0",
-          "Legal": "RESOLUTION POINTE PH 3 BLK  3A LT  27  G:2525",
-          "Valuation": "30000",
-          "formatted_address": "10554 Whitby Cir, Anchorage, AK 99515, USA",
-          "lat": "61.12496660000001",
-          "lng": "-149.9557343"
-        }
+        "Permit": "R20-1660",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "10554 WHITBY, Anchorage, Alaska",
+        "Parcel": "1140430000",
+        "Units": "0",
+        "Legal": "RESOLUTION POINTE PH 3 BLK  3A LT  27  G:2525",
+        "Valuation": "30000",
+        "formatted_address": "10554 Whitby Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -8111,21 +6911,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1725",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "2654 LOVEJOY DRIVE, Anchorage, Alaska",
-          "Parcel": "416405000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   4 LT   5  G:1534",
-          "Valuation": "12633",
-          "formatted_address": "2654 Lovejoy Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1965301",
-          "lng": "-149.8347342"
-        }
+        "Permit": "R20-1725",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "2654 LOVEJOY DRIVE, Anchorage, Alaska",
+        "Parcel": "416405000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   4 LT   5  G:1534",
+        "Valuation": "12633",
+        "formatted_address": "2654 Lovejoy Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -8138,21 +6934,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1726",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "8841 TEMPEST, Anchorage, Alaska",
-          "Parcel": "1431333000",
-          "Units": "0",
-          "Legal": "RIDGECREST BLK   3 LT  14  G:2335",
-          "Valuation": "10080",
-          "formatted_address": "8841 Tempest Cir, Anchorage, AK 99507, USA",
-          "lat": "61.14038339999999",
-          "lng": "-149.8122239"
-        }
+        "Permit": "R20-1726",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "8841 TEMPEST, Anchorage, Alaska",
+        "Parcel": "1431333000",
+        "Units": "0",
+        "Legal": "RIDGECREST BLK   3 LT  14  G:2335",
+        "Valuation": "10080",
+        "formatted_address": "8841 Tempest Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -8165,21 +6957,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1727",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "E 310 10TH, Anchorage, Alaska",
-          "Parcel": "213618000",
-          "Units": "0",
-          "Legal": "THIRD ADDITION BLK   7D LT   5  G:1331",
-          "Valuation": "13154",
-          "formatted_address": "310 W 10th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.212456",
-          "lng": "-149.8879989"
-        }
+        "Permit": "R20-1727",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "E 310 10TH, Anchorage, Alaska",
+        "Parcel": "213618000",
+        "Units": "0",
+        "Legal": "THIRD ADDITION BLK   7D LT   5  G:1331",
+        "Valuation": "13154",
+        "formatted_address": "310 W 10th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -8192,21 +6980,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1728",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "9103 SAHALEE, Anchorage, Alaska",
-          "Parcel": "1504424000",
-          "Units": "0",
-          "Legal": "SAHALEE BLK   2 LT   5  G:2336",
-          "Valuation": "14668",
-          "formatted_address": "9103 Sahalee Dr, Anchorage, AK 99507, USA",
-          "lat": "61.13877369999999",
-          "lng": "-149.7898453"
-        }
+        "Permit": "R20-1728",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "9103 SAHALEE, Anchorage, Alaska",
+        "Parcel": "1504424000",
+        "Units": "0",
+        "Legal": "SAHALEE BLK   2 LT   5  G:2336",
+        "Valuation": "14668",
+        "formatted_address": "9103 Sahalee Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -8219,21 +7003,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1729",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "E 3030 88TH, Anchorage, Alaska",
-          "Parcel": "1430103000",
-          "Units": "0",
-          "Legal": "GRANITE VIEW BLK   6 LT   9  G:2334",
-          "Valuation": "14968",
-          "formatted_address": "3030 W 88th Ave, Anchorage, AK 99502, USA",
-          "lat": "61.1409229",
-          "lng": "-149.9359777"
-        }
+        "Permit": "R20-1729",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "E 3030 88TH, Anchorage, Alaska",
+        "Parcel": "1430103000",
+        "Units": "0",
+        "Legal": "GRANITE VIEW BLK   6 LT   9  G:2334",
+        "Valuation": "14968",
+        "formatted_address": "3030 W 88th Ave, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -8246,21 +7026,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1730",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "18500 KITTIWAKE CIRCLE, Anchorage, Alaska",
-          "Parcel": "2020150000",
-          "Units": "0",
-          "Legal": "SOUTHCREEK BLK   1 LT  14  G:3537",
-          "Valuation": "13069",
-          "formatted_address": "18500 Kittiwake Cir, Anchorage, AK 99516, USA",
-          "lat": "61.0533709",
-          "lng": "-149.7752657"
-        }
+        "Permit": "R20-1730",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "18500 KITTIWAKE CIRCLE, Anchorage, Alaska",
+        "Parcel": "2020150000",
+        "Units": "0",
+        "Legal": "SOUTHCREEK BLK   1 LT  14  G:3537",
+        "Valuation": "13069",
+        "formatted_address": "18500 Kittiwake Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -8273,21 +7049,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1731",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "8831 SOLAR DRIVE, Anchorage, Alaska",
-          "Parcel": "1504321000",
-          "Units": "0",
-          "Legal": "ZODIAK MANOR ALASKA BLK   2 LT  21  G:2336",
-          "Valuation": "21074",
-          "formatted_address": "8831 Solar Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1401758",
-          "lng": "-149.8020954"
-        }
+        "Permit": "R20-1731",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "8831 SOLAR DRIVE, Anchorage, Alaska",
+        "Parcel": "1504321000",
+        "Units": "0",
+        "Legal": "ZODIAK MANOR ALASKA BLK   2 LT  21  G:2336",
+        "Valuation": "21074",
+        "formatted_address": "8831 Solar Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -8300,21 +7072,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1732",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "W 2305 TUDOR, Anchorage, Alaska",
-          "Parcel": "1020103000",
-          "Units": "0",
-          "Legal": "ROOSEVELT PARK BLK   8 LT  13  G:1728",
-          "Valuation": "8098",
-          "formatted_address": "2305 W Tudor Rd, Anchorage, AK 99517, USA",
-          "lat": "61.1810756",
-          "lng": "-149.925096"
-        }
+        "Permit": "R20-1732",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "W 2305 TUDOR, Anchorage, Alaska",
+        "Parcel": "1020103000",
+        "Units": "0",
+        "Legal": "ROOSEVELT PARK BLK   8 LT  13  G:1728",
+        "Valuation": "8098",
+        "formatted_address": "2305 W Tudor Rd, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -8327,21 +7095,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1733",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "16283 NOBLE POINT, Anchorage, Alaska",
-          "Parcel": "2049234000",
-          "Units": "0",
-          "Legal": "GOLDENVIEW PARK PH B2 BLK   4 LT  38  G:3236",
-          "Valuation": "16127",
-          "formatted_address": "16283 Noble Point Dr, Anchorage, AK 99516, USA",
-          "lat": "61.0737115",
-          "lng": "-149.7899437"
-        }
+        "Permit": "R20-1733",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "16283 NOBLE POINT, Anchorage, Alaska",
+        "Parcel": "2049234000",
+        "Units": "0",
+        "Legal": "GOLDENVIEW PARK PH B2 BLK   4 LT  38  G:3236",
+        "Valuation": "16127",
+        "formatted_address": "16283 Noble Point Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -8354,21 +7118,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1734",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/20",
-          "year": "2020",
-          "Address": "W 1643 10TH, Anchorage, Alaska",
-          "Parcel": "107236000",
-          "Units": "0",
-          "Legal": "L STREET SLIDE REPLAT BLK  13 LT   7A  G:1328",
-          "Valuation": "17990",
-          "formatted_address": "1643 W 10th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2127922",
-          "lng": "-149.915267"
-        }
+        "Permit": "R20-1734",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/20",
+        "year": "2020",
+        "Address": "W 1643 10TH, Anchorage, Alaska",
+        "Parcel": "107236000",
+        "Units": "0",
+        "Legal": "L STREET SLIDE REPLAT BLK  13 LT   7A  G:1328",
+        "Valuation": "17990",
+        "formatted_address": "1643 W 10th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -8381,21 +7141,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C20-1474",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "3502 SPENARD, Anchorage, Alaska",
-          "Parcel": "1010346000",
-          "Units": "0",
-          "Legal": "SPENARDIA LT   3  G:1629",
-          "Valuation": "58000",
-          "formatted_address": "3502 Spenard Rd, Anchorage, AK 99503, USA",
-          "lat": "61.1887402",
-          "lng": "-149.909261"
-        }
+        "Permit": "C20-1474",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "3502 SPENARD, Anchorage, Alaska",
+        "Parcel": "1010346000",
+        "Units": "0",
+        "Legal": "SPENARDIA LT   3  G:1629",
+        "Valuation": "58000",
+        "formatted_address": "3502 Spenard Rd, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -8408,21 +7164,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1847",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "6961 RABBIT CREEK ROAD, Anchorage, Alaska",
-          "Parcel": "1709159000",
-          "Units": "0",
-          "Legal": "PRATOR BLK   5 LT   2B  G:3039",
-          "Valuation": "13250",
-          "formatted_address": "6961 Rabbit Creek Rd, Anchorage, AK 99516, USA",
-          "lat": "61.0917178",
-          "lng": "-149.7532684"
-        }
+        "Permit": "R20-1847",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "6961 RABBIT CREEK ROAD, Anchorage, Alaska",
+        "Parcel": "1709159000",
+        "Units": "0",
+        "Legal": "PRATOR BLK   5 LT   2B  G:3039",
+        "Valuation": "13250",
+        "formatted_address": "6961 Rabbit Creek Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -8435,21 +7187,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1848",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "4351 DE ARMOUN, Anchorage, Alaska",
-          "Parcel": "1809264000",
-          "Units": "0",
-          "Legal": "T12N R3W SEC 27 LT  56A REM  G:2936",
-          "Valuation": "22105",
-          "formatted_address": "4351 De Armoun Rd, Anchorage, AK 99516, USA",
-          "lat": "61.09461209999999",
-          "lng": "-149.8007721"
-        }
+        "Permit": "R20-1848",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "4351 DE ARMOUN, Anchorage, Alaska",
+        "Parcel": "1809264000",
+        "Units": "0",
+        "Legal": "T12N R3W SEC 27 LT  56A REM  G:2936",
+        "Valuation": "22105",
+        "formatted_address": "4351 De Armoun Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -8462,21 +7210,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1849",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "2321 LEGACY, Anchorage, Alaska",
-          "Parcel": "1811472000",
-          "Units": "0",
-          "Legal": "HUFFMAN HILLS BLK   3 LT   6  G:2933",
-          "Valuation": "24900",
-          "formatted_address": "2321 Legacy Dr, Anchorage, AK 99516, USA",
-          "lat": "61.1013202",
-          "lng": "-149.8392909"
-        }
+        "Permit": "R20-1849",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "2321 LEGACY, Anchorage, Alaska",
+        "Parcel": "1811472000",
+        "Units": "0",
+        "Legal": "HUFFMAN HILLS BLK   3 LT   6  G:2933",
+        "Valuation": "24900",
+        "formatted_address": "2321 Legacy Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -8489,21 +7233,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1851",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "15927 BRIDGEVIEW, Anchorage, Alaska",
-          "Parcel": "2048211000",
-          "Units": "0",
-          "Legal": "GOLDENVIEW PARK PH B1 BLK   6 LT   6  G:3237",
-          "Valuation": "14868",
-          "formatted_address": "15927 Bridgeview Dr, Anchorage, AK 99516, USA",
-          "lat": "61.0761377",
-          "lng": "-149.7867097"
-        }
+        "Permit": "R20-1851",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "15927 BRIDGEVIEW, Anchorage, Alaska",
+        "Parcel": "2048211000",
+        "Units": "0",
+        "Legal": "GOLDENVIEW PARK PH B1 BLK   6 LT   6  G:3237",
+        "Valuation": "14868",
+        "formatted_address": "15927 Bridgeview Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -8516,21 +7256,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1852",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "12840 FOSTER ROAD, Anchorage, Alaska",
-          "Parcel": "1702303000",
-          "Units": "0",
-          "Legal": "MOUNTAIN PARK ESTATES #2 BLK   4 LT   3  G:2839",
-          "Valuation": "7864",
-          "formatted_address": "12840 Foster Rd, Anchorage, AK 99516, USA",
-          "lat": "61.10438430000001",
-          "lng": "-149.7494665"
-        }
+        "Permit": "R20-1852",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "12840 FOSTER ROAD, Anchorage, Alaska",
+        "Parcel": "1702303000",
+        "Units": "0",
+        "Legal": "MOUNTAIN PARK ESTATES #2 BLK   4 LT   3  G:2839",
+        "Valuation": "7864",
+        "formatted_address": "12840 Foster Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -8543,21 +7279,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1854",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "16788 WATERFORD POINTE, Anchorage, Alaska",
-          "Parcel": "2010317000",
-          "Units": "0",
-          "Legal": "PROMINENCE POINTE PH 8 BLK   6 LT  23 THE GATES OF  GOLDENVIEW G:3338",
-          "Valuation": "15372",
-          "formatted_address": "16788 Waterford Pointe Cir, Anchorage, AK 99516, USA",
-          "lat": "61.06950690000001",
-          "lng": "-149.7641136"
-        }
+        "Permit": "R20-1854",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "16788 WATERFORD POINTE, Anchorage, Alaska",
+        "Parcel": "2010317000",
+        "Units": "0",
+        "Legal": "PROMINENCE POINTE PH 8 BLK   6 LT  23 THE GATES OF  GOLDENVIEW G:3338",
+        "Valuation": "15372",
+        "formatted_address": "16788 Waterford Pointe Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -8570,21 +7302,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1855",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "19140 SCENIC HILL, Anchorage, Alaska",
-          "Parcel": "2029140000",
-          "Units": "0",
-          "Legal": "THE VILLAGES-PINE RIDGE LT   3  G:3637",
-          "Valuation": "18385",
-          "formatted_address": "19140 Scenic Hill Cir, Anchorage, AK 99516, USA",
-          "lat": "61.0484362",
-          "lng": "-149.7782159"
-        }
+        "Permit": "R20-1855",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "19140 SCENIC HILL, Anchorage, Alaska",
+        "Parcel": "2029140000",
+        "Units": "0",
+        "Legal": "THE VILLAGES-PINE RIDGE LT   3  G:3637",
+        "Valuation": "18385",
+        "formatted_address": "19140 Scenic Hill Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -8597,21 +7325,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1857",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "8933 SAHALEE, Anchorage, Alaska",
-          "Parcel": "1504438000",
-          "Units": "0",
-          "Legal": "SAHALEE BLK   2 LT  19  G:2336",
-          "Valuation": "12699",
-          "formatted_address": "8933 Sahalee Dr, Anchorage, AK 99507, USA",
-          "lat": "61.13983460000001",
-          "lng": "-149.7919037"
-        }
+        "Permit": "R20-1857",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "8933 SAHALEE, Anchorage, Alaska",
+        "Parcel": "1504438000",
+        "Units": "0",
+        "Legal": "SAHALEE BLK   2 LT  19  G:2336",
+        "Valuation": "12699",
+        "formatted_address": "8933 Sahalee Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -8624,21 +7348,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1858",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "E 4601 145TH, Anchorage, Alaska",
-          "Parcel": "1817245000",
-          "Units": "0",
-          "Legal": "ELMORE #2 BLK   8 LT  12  G:3036",
-          "Valuation": "17755",
-          "formatted_address": "4601 E 145th Ave, Anchorage, AK 99516, USA",
-          "lat": "61.0896989",
-          "lng": "-149.7961616"
-        }
+        "Permit": "R20-1858",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "E 4601 145TH, Anchorage, Alaska",
+        "Parcel": "1817245000",
+        "Units": "0",
+        "Legal": "ELMORE #2 BLK   8 LT  12  G:3036",
+        "Valuation": "17755",
+        "formatted_address": "4601 E 145th Ave, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -8651,21 +7371,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1859",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "9140 GRANITE PLACE, Anchorage, Alaska",
-          "Parcel": "1430234000",
-          "Units": "0",
-          "Legal": "GRANITE VIEW BLK 11   LT 8A  G:2334",
-          "Valuation": "22202",
-          "formatted_address": "9140 Granite Pl, Anchorage, AK 99507, USA",
-          "lat": "61.1379542",
-          "lng": "-149.8252269"
-        }
+        "Permit": "R20-1859",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "9140 GRANITE PLACE, Anchorage, Alaska",
+        "Parcel": "1430234000",
+        "Units": "0",
+        "Legal": "GRANITE VIEW BLK 11   LT 8A  G:2334",
+        "Valuation": "22202",
+        "formatted_address": "9140 Granite Pl, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -8678,21 +7394,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1892",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "4740 NEWCASTLE, Anchorage, Alaska",
-          "Parcel": "1022512000",
-          "Units": "0",
-          "Legal": "WINDEMERE #2 BLK   8 LT  23  G:1829",
-          "Valuation": "15772",
-          "formatted_address": "4740 Newcastle Way, Anchorage, AK 99503, USA",
-          "lat": "61.1777261",
-          "lng": "-149.9040403"
-        }
+        "Permit": "R20-1892",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "4740 NEWCASTLE, Anchorage, Alaska",
+        "Parcel": "1022512000",
+        "Units": "0",
+        "Legal": "WINDEMERE #2 BLK   8 LT  23  G:1829",
+        "Valuation": "15772",
+        "formatted_address": "4740 Newcastle Way, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -8705,21 +7417,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1893",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "5911 AUSTRIA, Anchorage, Alaska",
-          "Parcel": "2041317000",
-          "Units": "0",
-          "Legal": "PARADISE VALLEY BLK   7 LT   4  G:3538",
-          "Valuation": "13251",
-          "formatted_address": "5911 Austria Dr, Anchorage, AK 99516, USA",
-          "lat": "61.0576441",
-          "lng": "-149.7719688"
-        }
+        "Permit": "R20-1893",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "5911 AUSTRIA, Anchorage, Alaska",
+        "Parcel": "2041317000",
+        "Units": "0",
+        "Legal": "PARADISE VALLEY BLK   7 LT   4  G:3538",
+        "Valuation": "13251",
+        "formatted_address": "5911 Austria Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -8732,21 +7440,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1918",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "13940 JARVI, Anchorage, Alaska",
-          "Parcel": "1815120000",
-          "Units": "0",
-          "Legal": "SUNSET MANOR #2 BLK   6 LT  15  G:2932",
-          "Valuation": "6275",
-          "formatted_address": "13940 Jarvi Dr, Anchorage, AK 99515, USA",
-          "lat": "61.09426829999999",
-          "lng": "-149.8521868"
-        }
+        "Permit": "R20-1918",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "13940 JARVI, Anchorage, Alaska",
+        "Parcel": "1815120000",
+        "Units": "0",
+        "Legal": "SUNSET MANOR #2 BLK   6 LT  15  G:2932",
+        "Valuation": "6275",
+        "formatted_address": "13940 Jarvi Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -8759,21 +7463,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1935",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "3208 WYOMING, Anchorage, Alaska",
-          "Parcel": "1009632000",
-          "Units": "0",
-          "Legal": "WOODLAND PARK #2 BLK   3 LT   5  G:1628",
-          "Valuation": "9000",
-          "formatted_address": "3208 Wyoming Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19099809999999",
-          "lng": "-149.9174868"
-        }
+        "Permit": "R20-1935",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "3208 WYOMING, Anchorage, Alaska",
+        "Parcel": "1009632000",
+        "Units": "0",
+        "Legal": "WOODLAND PARK #2 BLK   3 LT   5  G:1628",
+        "Valuation": "9000",
+        "formatted_address": "3208 Wyoming Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -8786,21 +7486,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1936",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "3910 GENEVA, Anchorage, Alaska",
-          "Parcel": "324703000",
-          "Units": "0",
-          "Legal": "GENEVA WOODS BLK   5 LT   1  G:1732",
-          "Valuation": "11000",
-          "formatted_address": "3910 Geneva Pl, Anchorage, AK 99508, USA",
-          "lat": "61.18610609999999",
-          "lng": "-149.8593569"
-        }
+        "Permit": "R20-1936",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "3910 GENEVA, Anchorage, Alaska",
+        "Parcel": "324703000",
+        "Units": "0",
+        "Legal": "GENEVA WOODS BLK   5 LT   1  G:1732",
+        "Valuation": "11000",
+        "formatted_address": "3910 Geneva Pl, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -8813,21 +7509,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1937",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "4812 WESLEYAN, Anchorage, Alaska",
-          "Parcel": "515129000",
-          "Units": "0",
-          "Legal": "CASTLE HEIGHTS #1 BLK   5 LT   1  G:1737",
-          "Valuation": "15000",
-          "formatted_address": "4812 Wesleyan Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1851668",
-          "lng": "-149.7922157"
-        }
+        "Permit": "R20-1937",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "4812 WESLEYAN, Anchorage, Alaska",
+        "Parcel": "515129000",
+        "Units": "0",
+        "Legal": "CASTLE HEIGHTS #1 BLK   5 LT   1  G:1737",
+        "Valuation": "15000",
+        "formatted_address": "4812 Wesleyan Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -8840,21 +7532,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1995",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "6/30/20",
-          "year": "2020",
-          "Address": "3521 BISQUIER, Anchorage, Alaska",
-          "Parcel": "512368000",
-          "Units": "0",
-          "Legal": "COLLEGEGATE #8 BLK  16 LT   7  G:1637",
-          "Valuation": "39654",
-          "formatted_address": "3521 Bisquier Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1881381",
-          "lng": "-149.7868748"
-        }
+        "Permit": "R20-1995",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "6/30/20",
+        "year": "2020",
+        "Address": "3521 BISQUIER, Anchorage, Alaska",
+        "Parcel": "512368000",
+        "Units": "0",
+        "Legal": "COLLEGEGATE #8 BLK  16 LT   7  G:1637",
+        "Valuation": "39654",
+        "formatted_address": "3521 Bisquier Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -8867,21 +7555,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2072",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "18790 SERENE, Anchorage, Alaska",
-          "Parcel": "5031369000",
-          "Units": "0",
-          "Legal": "BRAENDEL CREEK LT  22  G:0154",
-          "Valuation": "24806",
-          "formatted_address": "18790 Serene Cir, Eagle River, AK 99577, USA",
-          "lat": "61.3204109",
-          "lng": "-149.5315184"
-        }
+        "Permit": "R20-2072",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "18790 SERENE, Anchorage, Alaska",
+        "Parcel": "5031369000",
+        "Units": "0",
+        "Legal": "BRAENDEL CREEK LT  22  G:0154",
+        "Valuation": "24806",
+        "formatted_address": "18790 Serene Cir, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -8894,21 +7578,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2073",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "E 3231 144TH, Anchorage, Alaska",
-          "Parcel": "1819213000",
-          "Units": "0",
-          "Legal": "T12N R3W SEC 33 LT  55 S180' LESS W110'  G:3034",
-          "Valuation": "13851",
-          "formatted_address": "3231 E 144th Ave, Anchorage, AK 99516, USA",
-          "lat": "61.09091979999999",
-          "lng": "-149.8213326"
-        }
+        "Permit": "R20-2073",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "E 3231 144TH, Anchorage, Alaska",
+        "Parcel": "1819213000",
+        "Units": "0",
+        "Legal": "T12N R3W SEC 33 LT  55 S180' LESS W110'  G:3034",
+        "Valuation": "13851",
+        "formatted_address": "3231 E 144th Ave, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -8921,21 +7601,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2074",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "12752 TANADA, Anchorage, Alaska",
-          "Parcel": "1802542000",
-          "Units": "0",
-          "Legal": "TANAGA TERRACE BLK   2 LT  14  G:2832",
-          "Valuation": "6232",
-          "formatted_address": "12752 Tanada Loop, Anchorage, AK 99515, USA",
-          "lat": "61.1055295",
-          "lng": "-149.8514444"
-        }
+        "Permit": "R20-2074",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "12752 TANADA, Anchorage, Alaska",
+        "Parcel": "1802542000",
+        "Units": "0",
+        "Legal": "TANAGA TERRACE BLK   2 LT  14  G:2832",
+        "Valuation": "6232",
+        "formatted_address": "12752 Tanada Loop, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -8948,21 +7624,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2075",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "8446 CORMORANT COVE, Anchorage, Alaska",
-          "Parcel": "1501614000",
-          "Units": "0",
-          "Legal": "SAHALEE PHASE 3 BLK   2 LT  46  G:2336",
-          "Valuation": "44143",
-          "formatted_address": "8446 Cormorant Cove Cir, Anchorage, AK 99507, USA",
-          "lat": "61.14393699999999",
-          "lng": "-149.7910672"
-        }
+        "Permit": "R20-2075",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "8446 CORMORANT COVE, Anchorage, Alaska",
+        "Parcel": "1501614000",
+        "Units": "0",
+        "Legal": "SAHALEE PHASE 3 BLK   2 LT  46  G:2336",
+        "Valuation": "44143",
+        "formatted_address": "8446 Cormorant Cove Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -8975,21 +7647,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2076",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "13520 WINDWARD, Anchorage, Alaska",
-          "Parcel": "1838317000",
-          "Units": "0",
-          "Legal": "TURNAGAIN VIEW #2 BLK   4 LT  44  G:2934",
-          "Valuation": "12496",
-          "formatted_address": "13520 Windward Ct, Anchorage, AK 99516, USA",
-          "lat": "61.09814830000001",
-          "lng": "-149.8261884"
-        }
+        "Permit": "R20-2076",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "13520 WINDWARD, Anchorage, Alaska",
+        "Parcel": "1838317000",
+        "Units": "0",
+        "Legal": "TURNAGAIN VIEW #2 BLK   4 LT  44  G:2934",
+        "Valuation": "12496",
+        "formatted_address": "13520 Windward Ct, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -9002,21 +7670,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2077",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "12750 TANADA, Anchorage, Alaska",
-          "Parcel": "1802542000",
-          "Units": "0",
-          "Legal": "TANAGA TERRACE BLK   2 LT  14  G:2832",
-          "Valuation": "9980",
-          "formatted_address": "12750 Tanada Loop, Anchorage, AK 99515, USA",
-          "lat": "61.1055679",
-          "lng": "-149.8514797"
-        }
+        "Permit": "R20-2077",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "12750 TANADA, Anchorage, Alaska",
+        "Parcel": "1802542000",
+        "Units": "0",
+        "Legal": "TANAGA TERRACE BLK   2 LT  14  G:2832",
+        "Valuation": "9980",
+        "formatted_address": "12750 Tanada Loop, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -9029,21 +7693,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2078",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "30800 PRUDHOE BAY, Anchorage, Alaska",
-          "Parcel": "5051130000",
-          "Units": "0",
-          "Legal": "NORTH SLOPE BLK   1 LT   3  G:0703",
-          "Valuation": "14292",
-          "formatted_address": "30800 Prudhoe Bay Ave, Eagle River, AK 99577, USA",
-          "lat": "61.25362699999999",
-          "lng": "-149.307143"
-        }
+        "Permit": "R20-2078",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "30800 PRUDHOE BAY, Anchorage, Alaska",
+        "Parcel": "5051130000",
+        "Units": "0",
+        "Legal": "NORTH SLOPE BLK   1 LT   3  G:0703",
+        "Valuation": "14292",
+        "formatted_address": "30800 Prudhoe Bay Ave, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -9056,21 +7716,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2079",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "18660 GENTEEL, Anchorage, Alaska",
-          "Parcel": "5031354000",
-          "Units": "0",
-          "Legal": "BRAENDEL CREEK LT   7  G:0154",
-          "Valuation": "24519",
-          "formatted_address": "18660 Genteel Cir, Eagle River, AK 99577, USA",
-          "lat": "61.320714",
-          "lng": "-149.536318"
-        }
+        "Permit": "R20-2079",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "18660 GENTEEL, Anchorage, Alaska",
+        "Parcel": "5031354000",
+        "Units": "0",
+        "Legal": "BRAENDEL CREEK LT   7  G:0154",
+        "Valuation": "24519",
+        "formatted_address": "18660 Genteel Cir, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -9083,21 +7739,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2130",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "W 3501 NORTHERN LIGHTS, Anchorage, Alaska",
-          "Parcel": "122629000",
-          "Units": "0",
-          "Legal": "SIMONSON HOMESTEAD LT  18C LT   4  G:1526",
-          "Valuation": "18000",
-          "formatted_address": "3501 E Northern Lights Blvd, Anchorage, AK 99508, USA",
-          "lat": "61.1989165",
-          "lng": "-149.8201707"
-        }
+        "Permit": "R20-2130",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "W 3501 NORTHERN LIGHTS, Anchorage, Alaska",
+        "Parcel": "122629000",
+        "Units": "0",
+        "Legal": "SIMONSON HOMESTEAD LT  18C LT   4  G:1526",
+        "Valuation": "18000",
+        "formatted_address": "3501 E Northern Lights Blvd, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -9110,21 +7762,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2132",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "1626 GARDEN STREET, Anchorage, Alaska",
-          "Parcel": "414207000",
-          "Units": "0",
-          "Legal": "SAXTON BLK   6 LT  12A  G:1434",
-          "Valuation": "5000",
-          "formatted_address": "1626 Garden St, Anchorage, AK 99508, USA",
-          "lat": "61.20552409999999",
-          "lng": "-149.8256404"
-        }
+        "Permit": "R20-2132",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "1626 GARDEN STREET, Anchorage, Alaska",
+        "Parcel": "414207000",
+        "Units": "0",
+        "Legal": "SAXTON BLK   6 LT  12A  G:1434",
+        "Valuation": "5000",
+        "formatted_address": "1626 Garden St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -9137,21 +7785,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2133",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "10210 JACKPOT BAY, Anchorage, Alaska",
-          "Parcel": "1247513000",
-          "Units": "0",
-          "Legal": "BAYSHORE WEST #4A BLK   2 LT   8  G:2526",
-          "Valuation": "15000",
-          "formatted_address": "10210 Jackpot Bay Cir, Anchorage, AK 99515, USA",
-          "lat": "61.1284125",
-          "lng": "-149.9382472"
-        }
+        "Permit": "R20-2133",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "10210 JACKPOT BAY, Anchorage, Alaska",
+        "Parcel": "1247513000",
+        "Units": "0",
+        "Legal": "BAYSHORE WEST #4A BLK   2 LT   8  G:2526",
+        "Valuation": "15000",
+        "formatted_address": "10210 Jackpot Bay Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -9164,21 +7808,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2134",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "2130 WASHINGTON AVENUE, Anchorage, Alaska",
-          "Parcel": "1256138000",
-          "Units": "0",
-          "Legal": "CONCORD HILL BLK   4 LT  36  G:2528",
-          "Valuation": "16000",
-          "formatted_address": "2130 Washington Ave, Anchorage, AK 99515, USA",
-          "lat": "61.12605769999999",
-          "lng": "-149.9193774"
-        }
+        "Permit": "R20-2134",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "2130 WASHINGTON AVENUE, Anchorage, Alaska",
+        "Parcel": "1256138000",
+        "Units": "0",
+        "Legal": "CONCORD HILL BLK   4 LT  36  G:2528",
+        "Valuation": "16000",
+        "formatted_address": "2130 Washington Ave, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -9191,21 +7831,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2271",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "9856 POSEIDON DRIVE, Anchorage, Alaska",
-          "Parcel": "1251379000",
-          "Units": "0",
-          "Legal": "OLYMPUS BLK   7 LT   5  G:2428",
-          "Valuation": "24990",
-          "formatted_address": "9856 Poseidon Dr, Anchorage, AK 99515, USA",
-          "lat": "61.131242",
-          "lng": "-149.9140319"
-        }
+        "Permit": "R20-2271",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "9856 POSEIDON DRIVE, Anchorage, Alaska",
+        "Parcel": "1251379000",
+        "Units": "0",
+        "Legal": "OLYMPUS BLK   7 LT   5  G:2428",
+        "Valuation": "24990",
+        "formatted_address": "9856 Poseidon Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -9218,21 +7854,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2284",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "8949 SAHALEE, Anchorage, Alaska",
-          "Parcel": "1504437000",
-          "Units": "0",
-          "Legal": "SAHALEE BLK   2 LT  18  G:2336",
-          "Valuation": "13252",
-          "formatted_address": "8949 Sahalee Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1395898",
-          "lng": "-149.7921374"
-        }
+        "Permit": "R20-2284",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "8949 SAHALEE, Anchorage, Alaska",
+        "Parcel": "1504437000",
+        "Units": "0",
+        "Legal": "SAHALEE BLK   2 LT  18  G:2336",
+        "Valuation": "13252",
+        "formatted_address": "8949 Sahalee Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -9245,21 +7877,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2286",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "4140 TERRACE DRIVE, Anchorage, Alaska",
-          "Parcel": "1108103000",
-          "Units": "0",
-          "Legal": "TOWN & COUNTRY ESTATES BLK   1 LT  21  G:2125",
-          "Valuation": "18335",
-          "formatted_address": "4140 Terrace Dr, Anchorage, AK 99502, USA",
-          "lat": "61.15756489999999",
-          "lng": "-149.9571393"
-        }
+        "Permit": "R20-2286",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "4140 TERRACE DRIVE, Anchorage, Alaska",
+        "Parcel": "1108103000",
+        "Units": "0",
+        "Legal": "TOWN & COUNTRY ESTATES BLK   1 LT  21  G:2125",
+        "Valuation": "18335",
+        "formatted_address": "4140 Terrace Dr, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -9272,21 +7900,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2290",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "14641 PARK HILLS, Anchorage, Alaska",
-          "Parcel": "1714216000",
-          "Units": "0",
-          "Legal": "PARK HILLS #1 BLK   2 LT   3  G:3037",
-          "Valuation": "26188",
-          "formatted_address": "14641 Park Hills Dr, Anchorage, AK 99516, USA",
-          "lat": "61.089191",
-          "lng": "-149.7785658"
-        }
+        "Permit": "R20-2290",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "14641 PARK HILLS, Anchorage, Alaska",
+        "Parcel": "1714216000",
+        "Units": "0",
+        "Legal": "PARK HILLS #1 BLK   2 LT   3  G:3037",
+        "Valuation": "26188",
+        "formatted_address": "14641 Park Hills Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -9299,21 +7923,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2293",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "8839 SAHALEE, Anchorage, Alaska",
-          "Parcel": "1504442000",
-          "Units": "0",
-          "Legal": "SAHALEE BLK   2 LT  23  G:2336",
-          "Valuation": "20676",
-          "formatted_address": "8839 Sahalee Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1402983",
-          "lng": "-149.7905116"
-        }
+        "Permit": "R20-2293",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "8839 SAHALEE, Anchorage, Alaska",
+        "Parcel": "1504442000",
+        "Units": "0",
+        "Legal": "SAHALEE BLK   2 LT  23  G:2336",
+        "Valuation": "20676",
+        "formatted_address": "8839 Sahalee Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -9326,21 +7946,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2299",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "7420 BEACON HILL, Anchorage, Alaska",
-          "Parcel": "1509292000",
-          "Units": "0",
-          "Legal": "BEACON HILL ESTATES LTS 4 & 5  G:2440",
-          "Valuation": "30053",
-          "formatted_address": "2807 Arctic Blvd, Anchorage, AK 99503, USA",
-          "lat": "61.1946991",
-          "lng": "-149.8975307"
-        }
+        "Permit": "R20-2299",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "7420 BEACON HILL, Anchorage, Alaska",
+        "Parcel": "1509292000",
+        "Units": "0",
+        "Legal": "BEACON HILL ESTATES LTS 4 & 5  G:2440",
+        "Valuation": "30053",
+        "formatted_address": "2807 Arctic Blvd, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -9353,21 +7969,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2322",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "3026 WESLEYAN, Anchorage, Alaska",
-          "Parcel": "511126000",
-          "Units": "0",
-          "Legal": "COLLEGEGATE BLK   4 LT  11  G:1637",
-          "Valuation": "18000",
-          "formatted_address": "3026 Wesleyan Dr, Anchorage, AK 99508, USA",
-          "lat": "61.19299640000001",
-          "lng": "-149.7902333"
-        }
+        "Permit": "R20-2322",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "3026 WESLEYAN, Anchorage, Alaska",
+        "Parcel": "511126000",
+        "Units": "0",
+        "Legal": "COLLEGEGATE BLK   4 LT  11  G:1637",
+        "Valuation": "18000",
+        "formatted_address": "3026 Wesleyan Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -9380,21 +7992,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2326",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "740 OLD KLATT, Anchorage, Alaska",
-          "Parcel": "1914231000",
-          "Units": "0",
-          "Legal": "TIMBERLANE PARK #1 BLK   2 LT   2 (P-209)  G:2729",
-          "Valuation": "9000",
-          "formatted_address": "740 Old Klatt Rd, Anchorage, AK 99515, USA",
-          "lat": "61.1136178",
-          "lng": "-149.8934735"
-        }
+        "Permit": "R20-2326",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "740 OLD KLATT, Anchorage, Alaska",
+        "Parcel": "1914231000",
+        "Units": "0",
+        "Legal": "TIMBERLANE PARK #1 BLK   2 LT   2 (P-209)  G:2729",
+        "Valuation": "9000",
+        "formatted_address": "740 Old Klatt Rd, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -9407,21 +8015,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2327",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "7/31/20",
-          "year": "2020",
-          "Address": "7715 EASTBROOK, Anchorage, Alaska",
-          "Parcel": "635562000",
-          "Units": "0",
-          "Legal": "EASTBROOK BLK   2 LT   8  G:1540",
-          "Valuation": "16000",
-          "formatted_address": "7715 Eastbrook Dr, Anchorage, AK 99504, USA",
-          "lat": "61.19993089999999",
-          "lng": "-149.7364599"
-        }
+        "Permit": "R20-2327",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "7/31/20",
+        "year": "2020",
+        "Address": "7715 EASTBROOK, Anchorage, Alaska",
+        "Parcel": "635562000",
+        "Units": "0",
+        "Legal": "EASTBROOK BLK   2 LT   8  G:1540",
+        "Valuation": "16000",
+        "formatted_address": "7715 Eastbrook Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -9434,21 +8038,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2365",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "3209 LOIS, Anchorage, Alaska",
-          "Parcel": "1009520000",
-          "Units": "0",
-          "Legal": "WOODLAND PARK #2 BLK   4 LT  14  G:1628",
-          "Valuation": "11982",
-          "formatted_address": "3209 Lois Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1910618",
-          "lng": "-149.9200636"
-        }
+        "Permit": "R20-2365",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "3209 LOIS, Anchorage, Alaska",
+        "Parcel": "1009520000",
+        "Units": "0",
+        "Legal": "WOODLAND PARK #2 BLK   4 LT  14  G:1628",
+        "Valuation": "11982",
+        "formatted_address": "3209 Lois Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -9461,21 +8061,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2374",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "6850 CROOKED TREE, Anchorage, Alaska",
-          "Parcel": "1512328000",
-          "Units": "0",
-          "Legal": "VALLI VUE ESTATES #2 BLK   6 LT  24  G:2539",
-          "Valuation": "13971",
-          "formatted_address": "6850 Crooked Tree Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1281468",
-          "lng": "-149.7540709"
-        }
+        "Permit": "R20-2374",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "6850 CROOKED TREE, Anchorage, Alaska",
+        "Parcel": "1512328000",
+        "Units": "0",
+        "Legal": "VALLI VUE ESTATES #2 BLK   6 LT  24  G:2539",
+        "Valuation": "13971",
+        "formatted_address": "6850 Crooked Tree Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -9488,21 +8084,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2375",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "6255 PROMINENCE POINTE, Anchorage, Alaska",
-          "Parcel": "2010316000",
-          "Units": "0",
-          "Legal": "PROMINENCE POINTE PH 8 BLK   6 LT  22 THE GATES OF GOLDENVIEW G:3338",
-          "Valuation": "16372",
-          "formatted_address": "6255 Prominence Pointe Dr, Anchorage, AK 99516, USA",
-          "lat": "61.0691305",
-          "lng": "-149.7644252"
-        }
+        "Permit": "R20-2375",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "6255 PROMINENCE POINTE, Anchorage, Alaska",
+        "Parcel": "2010316000",
+        "Units": "0",
+        "Legal": "PROMINENCE POINTE PH 8 BLK   6 LT  22 THE GATES OF GOLDENVIEW G:3338",
+        "Valuation": "16372",
+        "formatted_address": "6255 Prominence Pointe Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -9515,21 +8107,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2378",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "9607 MUSKET BALL, Anchorage, Alaska",
-          "Parcel": "1625321000",
-          "Units": "0",
-          "Legal": "INDEPENDENCE PARK BLK  17 LT   1  G:2433",
-          "Valuation": "11558",
-          "formatted_address": "9607 Musket Ball Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1340235",
-          "lng": "-149.8422281"
-        }
+        "Permit": "R20-2378",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "9607 MUSKET BALL, Anchorage, Alaska",
+        "Parcel": "1625321000",
+        "Units": "0",
+        "Legal": "INDEPENDENCE PARK BLK  17 LT   1  G:2433",
+        "Valuation": "11558",
+        "formatted_address": "9607 Musket Ball Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -9542,21 +8130,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2379",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "514 RIVERSTONE, Anchorage, Alaska",
-          "Parcel": "1313130062",
-          "Units": "0",
-          "Legal": "RIVER PARK TR   A RIVER PARK G:2131",
-          "Valuation": "23731",
-          "formatted_address": "514 Riverstone Way, Anchorage, AK 99518, USA",
-          "lat": "61.15648729999999",
-          "lng": "-149.8721669"
-        }
+        "Permit": "R20-2379",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "514 RIVERSTONE, Anchorage, Alaska",
+        "Parcel": "1313130062",
+        "Units": "0",
+        "Legal": "RIVER PARK TR   A RIVER PARK G:2131",
+        "Valuation": "23731",
+        "formatted_address": "514 Riverstone Way, Anchorage, AK 99518, USA"
       }
     },
     {
@@ -9569,21 +8153,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2445",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "8786 ESTATES CIRCLE, Anchorage, Alaska",
-          "Parcel": "1424446000",
-          "Units": "0",
-          "Legal": "SPRUCE RIDGE ESTATES LT   1  G:2335",
-          "Valuation": "23202",
-          "formatted_address": "8786 Estates Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1414275",
-          "lng": "-149.8153789"
-        }
+        "Permit": "R20-2445",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "8786 ESTATES CIRCLE, Anchorage, Alaska",
+        "Parcel": "1424446000",
+        "Units": "0",
+        "Legal": "SPRUCE RIDGE ESTATES LT   1  G:2335",
+        "Valuation": "23202",
+        "formatted_address": "8786 Estates Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -9596,21 +8176,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2447",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "3621 HOLLYBERRY, Anchorage, Alaska",
-          "Parcel": "1408239000",
-          "Units": "0",
-          "Legal": "RASPBERRY BLK   1 LT  13  G:2135",
-          "Valuation": "6732",
-          "formatted_address": "3621 Hollyberry Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1579333",
-          "lng": "-149.8146322"
-        }
+        "Permit": "R20-2447",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "3621 HOLLYBERRY, Anchorage, Alaska",
+        "Parcel": "1408239000",
+        "Units": "0",
+        "Legal": "RASPBERRY BLK   1 LT  13  G:2135",
+        "Valuation": "6732",
+        "formatted_address": "3621 Hollyberry Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -9623,21 +8199,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2448",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "11945 CIRCLE DRIVE, Anchorage, Alaska",
-          "Parcel": "1524315000",
-          "Units": "0",
-          "Legal": "ALPINE TERRACE BLK   4 LT   1  G:2740",
-          "Valuation": "15892",
-          "formatted_address": "11945 Circle Dr, Anchorage, AK 99507, USA",
-          "lat": "61.11252339999999",
-          "lng": "-149.7377254"
-        }
+        "Permit": "R20-2448",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "11945 CIRCLE DRIVE, Anchorage, Alaska",
+        "Parcel": "1524315000",
+        "Units": "0",
+        "Legal": "ALPINE TERRACE BLK   4 LT   1  G:2740",
+        "Valuation": "15892",
+        "formatted_address": "11945 Circle Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -9650,21 +8222,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2452",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "W 1037 26TH, Anchorage, Alaska",
-          "Parcel": "125291000",
-          "Units": "0",
-          "Legal": "SUNBEAM BLK   1 LT   6 W50'  G:1529",
-          "Valuation": "23100",
-          "formatted_address": "1037 E 26th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.19757430000001",
-          "lng": "-149.862695"
-        }
+        "Permit": "R20-2452",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "W 1037 26TH, Anchorage, Alaska",
+        "Parcel": "125291000",
+        "Units": "0",
+        "Legal": "SUNBEAM BLK   1 LT   6 W50'  G:1529",
+        "Valuation": "23100",
+        "formatted_address": "1037 E 26th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -9677,21 +8245,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2500",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "2401 CAPTAIN COOK, Anchorage, Alaska",
-          "Parcel": "123527000",
-          "Units": "0",
-          "Legal": "TURNAGAIN HOMES BLK   E LT  20A  G:1527",
-          "Valuation": "9500",
-          "formatted_address": "2401 Captain Cook Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1988314",
-          "lng": "-149.9388171"
-        }
+        "Permit": "R20-2500",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "2401 CAPTAIN COOK, Anchorage, Alaska",
+        "Parcel": "123527000",
+        "Units": "0",
+        "Legal": "TURNAGAIN HOMES BLK   E LT  20A  G:1527",
+        "Valuation": "9500",
+        "formatted_address": "2401 Captain Cook Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -9704,21 +8268,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2545",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "7541 SOLDOTNA, Anchorage, Alaska",
-          "Parcel": "1524330000",
-          "Units": "0",
-          "Legal": "ALPINE TERRACE BLK   1 LT   6  G:2740",
-          "Valuation": "18000",
-          "formatted_address": "7541 Soldotna Dr, Anchorage, AK 99507, USA",
-          "lat": "61.11481759999999",
-          "lng": "-149.7423251"
-        }
+        "Permit": "R20-2545",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "7541 SOLDOTNA, Anchorage, Alaska",
+        "Parcel": "1524330000",
+        "Units": "0",
+        "Legal": "ALPINE TERRACE BLK   1 LT   6  G:2740",
+        "Valuation": "18000",
+        "formatted_address": "7541 Soldotna Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -9731,21 +8291,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2547",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "2111 BELMONT, Anchorage, Alaska",
-          "Parcel": "117338000",
-          "Units": "0",
-          "Legal": "HUNTINGTON PARK #5A BLK   5 LT  37  G:1528",
-          "Valuation": "21000",
-          "formatted_address": "2111 Belmont Dr, Anchorage, AK 99517, USA",
-          "lat": "61.20057680000001",
-          "lng": "-149.9257662"
-        }
+        "Permit": "R20-2547",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "2111 BELMONT, Anchorage, Alaska",
+        "Parcel": "117338000",
+        "Units": "0",
+        "Legal": "HUNTINGTON PARK #5A BLK   5 LT  37  G:1528",
+        "Valuation": "21000",
+        "formatted_address": "2111 Belmont Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -9758,21 +8314,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2548",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "2054 ARLINGTON, Anchorage, Alaska",
-          "Parcel": "124408000",
-          "Units": "0",
-          "Legal": "HUNTINGTON PARK #2 BLK   4 LT  17  G:1528",
-          "Valuation": "10000",
-          "formatted_address": "2054 Arlington Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1971198",
-          "lng": "-149.9231613"
-        }
+        "Permit": "R20-2548",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "2054 ARLINGTON, Anchorage, Alaska",
+        "Parcel": "124408000",
+        "Units": "0",
+        "Legal": "HUNTINGTON PARK #2 BLK   4 LT  17  G:1528",
+        "Valuation": "10000",
+        "formatted_address": "2054 Arlington Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -9785,21 +8337,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2549",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "3838 WESTMINSTER, Anchorage, Alaska",
-          "Parcel": "515159000",
-          "Units": "0",
-          "Legal": "CASTLE HEIGHTS #2 BLK   6 LT  36  G:1737",
-          "Valuation": "22000",
-          "formatted_address": "3838 Westminster Way, Anchorage, AK 99508, USA",
-          "lat": "61.1859193",
-          "lng": "-149.7909709"
-        }
+        "Permit": "R20-2549",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "3838 WESTMINSTER, Anchorage, Alaska",
+        "Parcel": "515159000",
+        "Units": "0",
+        "Legal": "CASTLE HEIGHTS #2 BLK   6 LT  36  G:1737",
+        "Valuation": "22000",
+        "formatted_address": "3838 Westminster Way, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -9812,21 +8360,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2551",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "7803 BRENTWOOD, Anchorage, Alaska",
-          "Parcel": "1110110000",
-          "Units": "0",
-          "Legal": "BRENTWOOD BLK   2 LT   4  G:2225",
-          "Valuation": "12180",
-          "formatted_address": "7803 Brentwood Dr, Anchorage, AK 99502, USA",
-          "lat": "61.1500871",
-          "lng": "-149.953623"
-        }
+        "Permit": "R20-2551",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "7803 BRENTWOOD, Anchorage, Alaska",
+        "Parcel": "1110110000",
+        "Units": "0",
+        "Legal": "BRENTWOOD BLK   2 LT   4  G:2225",
+        "Valuation": "12180",
+        "formatted_address": "7803 Brentwood Dr, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -9839,21 +8383,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2553",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "16841 RANSOM RIDGE, Anchorage, Alaska",
-          "Parcel": "2009274000",
-          "Units": "0",
-          "Legal": "RANSOM RIDGE LT   2B  G:3337",
-          "Valuation": "17694",
-          "formatted_address": "16841 Ransom Ridge Rd, Anchorage, AK 99516, USA",
-          "lat": "61.0680699",
-          "lng": "-149.7751323"
-        }
+        "Permit": "R20-2553",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "16841 RANSOM RIDGE, Anchorage, Alaska",
+        "Parcel": "2009274000",
+        "Units": "0",
+        "Legal": "RANSOM RIDGE LT   2B  G:3337",
+        "Valuation": "17694",
+        "formatted_address": "16841 Ransom Ridge Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -9866,21 +8406,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2554",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "13501 SPENDLOVE, Anchorage, Alaska",
-          "Parcel": "2102114000",
-          "Units": "0",
-          "Legal": "SPENDLOVE VIEW HEIGHTS BLK   3 LT   6  G:2942",
-          "Valuation": "30336",
-          "formatted_address": "13501 Spendlove Dr, Anchorage, AK 99516, USA",
-          "lat": "61.0982996",
-          "lng": "-149.7091117"
-        }
+        "Permit": "R20-2554",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "13501 SPENDLOVE, Anchorage, Alaska",
+        "Parcel": "2102114000",
+        "Units": "0",
+        "Legal": "SPENDLOVE VIEW HEIGHTS BLK   3 LT   6  G:2942",
+        "Valuation": "30336",
+        "formatted_address": "13501 Spendlove Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -9893,21 +8429,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2555",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/20",
-          "year": "2020",
-          "Address": "5241 TAURUS CIRCLE, Anchorage, Alaska",
-          "Parcel": "2009232000",
-          "Units": "0",
-          "Legal": "LOMA ESTATES BLK   3 LT   3  G:3337",
-          "Valuation": "16276",
-          "formatted_address": "5241 Taurus Cir, Anchorage, AK 99516, USA",
-          "lat": "61.06851340000001",
-          "lng": "-149.7841809"
-        }
+        "Permit": "R20-2555",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/20",
+        "year": "2020",
+        "Address": "5241 TAURUS CIRCLE, Anchorage, Alaska",
+        "Parcel": "2009232000",
+        "Units": "0",
+        "Legal": "LOMA ESTATES BLK   3 LT   3  G:3337",
+        "Valuation": "16276",
+        "formatted_address": "5241 Taurus Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -9920,21 +8452,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2663",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/20",
-          "year": "2020",
-          "Address": "7841 TALISMAN ROAD, Anchorage, Alaska",
-          "Parcel": "1742233000",
-          "Units": "0",
-          "Legal": "STELIOES LT   2  G:2840",
-          "Valuation": "18094",
-          "formatted_address": "7841 Talisman Rd, Anchorage, AK 99516, USA",
-          "lat": "61.10533059999999",
-          "lng": "-149.7355359"
-        }
+        "Permit": "R20-2663",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/20",
+        "year": "2020",
+        "Address": "7841 TALISMAN ROAD, Anchorage, Alaska",
+        "Parcel": "1742233000",
+        "Units": "0",
+        "Legal": "STELIOES LT   2  G:2840",
+        "Valuation": "18094",
+        "formatted_address": "7841 Talisman Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -9947,21 +8475,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2664",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/20",
-          "year": "2020",
-          "Address": "4836 BLUE HERON CIRCLE, Anchorage, Alaska",
-          "Parcel": "1504414000",
-          "Units": "0",
-          "Legal": "SAHALEE BLK   1 LT  40  G:2336",
-          "Valuation": "13925",
-          "formatted_address": "4836 Blue Heron Cir, Anchorage, AK 99507, USA",
-          "lat": "61.13864650000001",
-          "lng": "-149.7921944"
-        }
+        "Permit": "R20-2664",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/20",
+        "year": "2020",
+        "Address": "4836 BLUE HERON CIRCLE, Anchorage, Alaska",
+        "Parcel": "1504414000",
+        "Units": "0",
+        "Legal": "SAHALEE BLK   1 LT  40  G:2336",
+        "Valuation": "13925",
+        "formatted_address": "4836 Blue Heron Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -9974,21 +8498,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2665",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/20",
-          "year": "2020",
-          "Address": "4790 BLUE HERON CIRCLE, Anchorage, Alaska",
-          "Parcel": "1504466000",
-          "Units": "0",
-          "Legal": "SAHALEE PH 4 BLK   1 LT  37  G:2336",
-          "Valuation": "18094",
-          "formatted_address": "4790 Blue Heron Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1380435",
-          "lng": "-149.7926107"
-        }
+        "Permit": "R20-2665",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/20",
+        "year": "2020",
+        "Address": "4790 BLUE HERON CIRCLE, Anchorage, Alaska",
+        "Parcel": "1504466000",
+        "Units": "0",
+        "Legal": "SAHALEE PH 4 BLK   1 LT  37  G:2336",
+        "Valuation": "18094",
+        "formatted_address": "4790 Blue Heron Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -10001,21 +8521,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2775",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/20",
-          "year": "2020",
-          "Address": "E 3911 66TH, Anchorage, Alaska",
-          "Parcel": "1407663000",
-          "Units": "0",
-          "Legal": "CAMPBELL HEIGHTS BLK   5 LT  39A  G:2035",
-          "Valuation": "15468",
-          "formatted_address": "3911 E 66th Ave, Anchorage, AK 99507, USA",
-          "lat": "61.16124989999999",
-          "lng": "-149.8095224"
-        }
+        "Permit": "R20-2775",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/20",
+        "year": "2020",
+        "Address": "E 3911 66TH, Anchorage, Alaska",
+        "Parcel": "1407663000",
+        "Units": "0",
+        "Legal": "CAMPBELL HEIGHTS BLK   5 LT  39A  G:2035",
+        "Valuation": "15468",
+        "formatted_address": "3911 E 66th Ave, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -10028,21 +8544,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2777",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/20",
-          "year": "2020",
-          "Address": "10540 KASILOF, Anchorage, Alaska",
-          "Parcel": "1513123000",
-          "Units": "0",
-          "Legal": "KASILOF HILLS BLK   4 LT   9  G:2541",
-          "Valuation": "20214",
-          "formatted_address": "10540 Kasilof Blvd, Anchorage, AK 99507, USA",
-          "lat": "61.1251043",
-          "lng": "-149.7223308"
-        }
+        "Permit": "R20-2777",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/20",
+        "year": "2020",
+        "Address": "10540 KASILOF, Anchorage, Alaska",
+        "Parcel": "1513123000",
+        "Units": "0",
+        "Legal": "KASILOF HILLS BLK   4 LT   9  G:2541",
+        "Valuation": "20214",
+        "formatted_address": "10540 Kasilof Blvd, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -10055,21 +8567,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2782",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/20",
-          "year": "2020",
-          "Address": "780 HUNT CIRCLE, Anchorage, Alaska",
-          "Parcel": "609133000",
-          "Units": "0",
-          "Legal": "HUNTWOOD #1 BLK   3 LT  17  G:1339",
-          "Valuation": "13410",
-          "formatted_address": "780 Hunt Cir, Anchorage, AK 99504, USA",
-          "lat": "61.21502979999999",
-          "lng": "-149.749856"
-        }
+        "Permit": "R20-2782",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/20",
+        "year": "2020",
+        "Address": "780 HUNT CIRCLE, Anchorage, Alaska",
+        "Parcel": "609133000",
+        "Units": "0",
+        "Legal": "HUNTWOOD #1 BLK   3 LT  17  G:1339",
+        "Valuation": "13410",
+        "formatted_address": "780 Hunt Cir, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -10082,21 +8590,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2793",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "9/30/20",
-          "year": "2020",
-          "Address": "3433 SEPPALA DRIVE, Anchorage, Alaska",
-          "Parcel": "122115000",
-          "Units": "0",
-          "Legal": "TURNAGAIN HOMES BLK   O LT  33  G:1526",
-          "Valuation": "18000",
-          "formatted_address": "3433 Seppala Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19607769999999",
-          "lng": "-149.9495478"
-        }
+        "Permit": "R20-2793",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "9/30/20",
+        "year": "2020",
+        "Address": "3433 SEPPALA DRIVE, Anchorage, Alaska",
+        "Parcel": "122115000",
+        "Units": "0",
+        "Legal": "TURNAGAIN HOMES BLK   O LT  33  G:1526",
+        "Valuation": "18000",
+        "formatted_address": "3433 Seppala Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -10109,21 +8613,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2794",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "9/30/20",
-          "year": "2020",
-          "Address": "E 5086 98TH, Anchorage, Alaska",
-          "Parcel": "1507425000",
-          "Units": "0",
-          "Legal": "WILLIAMSON #2 BLK   2 LT  26A  G:2437",
-          "Valuation": "22000",
-          "formatted_address": "5086 E 98th Ave, Anchorage, AK 99507, USA",
-          "lat": "61.13323679999999",
-          "lng": "-149.7857748"
-        }
+        "Permit": "R20-2794",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "9/30/20",
+        "year": "2020",
+        "Address": "E 5086 98TH, Anchorage, Alaska",
+        "Parcel": "1507425000",
+        "Units": "0",
+        "Legal": "WILLIAMSON #2 BLK   2 LT  26A  G:2437",
+        "Valuation": "22000",
+        "formatted_address": "5086 E 98th Ave, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -10136,21 +8636,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2796",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "9/30/20",
-          "year": "2020",
-          "Address": "3821 REFLECTION DRIVE, Anchorage, Alaska",
-          "Parcel": "709286000",
-          "Units": "0",
-          "Legal": "REFLECTION LAKE BLK   3 LT  20R  G:1738",
-          "Valuation": "18000",
-          "formatted_address": "3821 Reflection Dr, Anchorage, AK 99504, USA",
-          "lat": "61.186013",
-          "lng": "-149.7741381"
-        }
+        "Permit": "R20-2796",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "9/30/20",
+        "year": "2020",
+        "Address": "3821 REFLECTION DRIVE, Anchorage, Alaska",
+        "Parcel": "709286000",
+        "Units": "0",
+        "Legal": "REFLECTION LAKE BLK   3 LT  20R  G:1738",
+        "Valuation": "18000",
+        "formatted_address": "3821 Reflection Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -10163,21 +8659,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2836",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/20",
-          "year": "2020",
-          "Address": "8201 CLARKS ROAD, Anchorage, Alaska",
-          "Parcel": "4209139000",
-          "Units": "0",
-          "Legal": "T12N R2W SEC 31 LT   3 S2  G:3142",
-          "Valuation": "79630",
-          "formatted_address": "8201 Clarks Rd, Anchorage, AK 99516, USA",
-          "lat": "61.0846336",
-          "lng": "-149.7121391"
-        }
+        "Permit": "R20-2836",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/20",
+        "year": "2020",
+        "Address": "8201 CLARKS ROAD, Anchorage, Alaska",
+        "Parcel": "4209139000",
+        "Units": "0",
+        "Legal": "T12N R2W SEC 31 LT   3 S2  G:3142",
+        "Valuation": "79630",
+        "formatted_address": "8201 Clarks Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -10190,21 +8682,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2842",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "10/31/20",
-          "year": "2020",
-          "Address": "6120 ROMANIA, Anchorage, Alaska",
-          "Parcel": "2041402000",
-          "Units": "0",
-          "Legal": "PARADISE VALLEY BLK   9 LT  14  G:3538",
-          "Valuation": "11184",
-          "formatted_address": "6120 Romania Dr, Anchorage, AK 99516, USA",
-          "lat": "61.0545795",
-          "lng": "-149.7675099"
-        }
+        "Permit": "R20-2842",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "10/31/20",
+        "year": "2020",
+        "Address": "6120 ROMANIA, Anchorage, Alaska",
+        "Parcel": "2041402000",
+        "Units": "0",
+        "Legal": "PARADISE VALLEY BLK   9 LT  14  G:3538",
+        "Valuation": "11184",
+        "formatted_address": "6120 Romania Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -10217,21 +8705,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2843",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "10/31/20",
-          "year": "2020",
-          "Address": "7708 CHAIMI, Anchorage, Alaska",
-          "Parcel": "712736000",
-          "Units": "0",
-          "Legal": "CHUGACH MOUNTAIN ESTATES BLK   3 LT  10  G:1740",
-          "Valuation": "8664",
-          "formatted_address": "7708 Chaimi Loop, Anchorage, AK 99504, USA",
-          "lat": "61.1809829",
-          "lng": "-149.7360493"
-        }
+        "Permit": "R20-2843",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "10/31/20",
+        "year": "2020",
+        "Address": "7708 CHAIMI, Anchorage, Alaska",
+        "Parcel": "712736000",
+        "Units": "0",
+        "Legal": "CHUGACH MOUNTAIN ESTATES BLK   3 LT  10  G:1740",
+        "Valuation": "8664",
+        "formatted_address": "7708 Chaimi Loop, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -10244,21 +8728,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2915",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "10/31/20",
-          "year": "2020",
-          "Address": "2400 SUSITNA, Anchorage, Alaska",
-          "Parcel": "122322000",
-          "Units": "0",
-          "Legal": "TURNAGAIN HOMES BLK   R LT  10  G:1526",
-          "Valuation": "21000",
-          "formatted_address": "2400 Susitna Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19887610000001",
-          "lng": "-149.9488937"
-        }
+        "Permit": "R20-2915",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "10/31/20",
+        "year": "2020",
+        "Address": "2400 SUSITNA, Anchorage, Alaska",
+        "Parcel": "122322000",
+        "Units": "0",
+        "Legal": "TURNAGAIN HOMES BLK   R LT  10  G:1526",
+        "Valuation": "21000",
+        "formatted_address": "2400 Susitna Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -10271,21 +8751,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-2943",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "10/31/20",
-          "year": "2020",
-          "Address": "2900 CHESAPEAKE, Anchorage, Alaska",
-          "Parcel": "1735150000",
-          "Units": "0",
-          "Legal": "KEMPTON HILLS BLK   1 LT   6  G:2834",
-          "Valuation": "12590",
-          "formatted_address": "2900 Chesapeake Ave, Anchorage, AK 99516, USA",
-          "lat": "61.101585",
-          "lng": "-149.8282853"
-        }
+        "Permit": "R20-2943",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "10/31/20",
+        "year": "2020",
+        "Address": "2900 CHESAPEAKE, Anchorage, Alaska",
+        "Parcel": "1735150000",
+        "Units": "0",
+        "Legal": "KEMPTON HILLS BLK   1 LT   6  G:2834",
+        "Valuation": "12590",
+        "formatted_address": "2900 Chesapeake Ave, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -10298,21 +8774,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-3090",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "11/30/20",
-          "year": "2020",
-          "Address": "5532 YUKON CHARLIE, Anchorage, Alaska",
-          "Parcel": "1131246000",
-          "Units": "0",
-          "Legal": "WESTPARK ADDN 5 BLK  10 LT   6  G:2223",
-          "Valuation": "21000",
-          "formatted_address": "5532 Yukon Charlie Loop, Anchorage, AK 99502, USA",
-          "lat": "61.1511187",
-          "lng": "-149.9874929"
-        }
+        "Permit": "R20-3090",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "11/30/20",
+        "year": "2020",
+        "Address": "5532 YUKON CHARLIE, Anchorage, Alaska",
+        "Parcel": "1131246000",
+        "Units": "0",
+        "Legal": "WESTPARK ADDN 5 BLK  10 LT   6  G:2223",
+        "Valuation": "21000",
+        "formatted_address": "5532 Yukon Charlie Loop, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -10325,21 +8797,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C20-2180",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "12/31/20",
-          "year": "2020",
-          "Address": "E 15500 EAGLE RIVER LOOP, Anchorage, Alaska",
-          "Parcel": "6029101000",
-          "Units": "0",
-          "Legal": "ALASKA ST LAND SURVEY 88-211 LT   1A MUNICIPAL LANDFILL G:0249",
-          "Valuation": "177822",
-          "formatted_address": "15500 N Eagle River Loop Rd, Eagle River, AK 99577, USA",
-          "lat": "61.3290948",
-          "lng": "-149.566354"
-        }
+        "Permit": "C20-2180",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "12/31/20",
+        "year": "2020",
+        "Address": "E 15500 EAGLE RIVER LOOP, Anchorage, Alaska",
+        "Parcel": "6029101000",
+        "Units": "0",
+        "Legal": "ALASKA ST LAND SURVEY 88-211 LT   1A MUNICIPAL LANDFILL G:0249",
+        "Valuation": "177822",
+        "formatted_address": "15500 N Eagle River Loop Rd, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -10352,21 +8820,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-3200",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "12/31/20",
-          "year": "2020",
-          "Address": "E 3306 16TH, Anchorage, Alaska",
-          "Parcel": "413103000",
-          "Units": "0",
-          "Legal": "THUNDERBIRD TERRACE BLK   1 LT   9  G:1435",
-          "Valuation": "11351",
-          "formatted_address": "3306 E 16th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.2059098",
-          "lng": "-149.8196141"
-        }
+        "Permit": "R20-3200",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "12/31/20",
+        "year": "2020",
+        "Address": "E 3306 16TH, Anchorage, Alaska",
+        "Parcel": "413103000",
+        "Units": "0",
+        "Legal": "THUNDERBIRD TERRACE BLK   1 LT   9  G:1435",
+        "Valuation": "11351",
+        "formatted_address": "3306 E 16th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -10379,21 +8843,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-3202",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "12/31/20",
-          "year": "2020",
-          "Address": "17401 SPAIN, Anchorage, Alaska",
-          "Parcel": "2017117000",
-          "Units": "0",
-          "Legal": "KENO HILLS #1 BLK   4 LT   3  G:3438",
-          "Valuation": "12914",
-          "formatted_address": "17401 Spain Dr, Anchorage, AK 99516, USA",
-          "lat": "61.06345669999999",
-          "lng": "-149.7655194"
-        }
+        "Permit": "R20-3202",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "12/31/20",
+        "year": "2020",
+        "Address": "17401 SPAIN, Anchorage, Alaska",
+        "Parcel": "2017117000",
+        "Units": "0",
+        "Legal": "KENO HILLS #1 BLK   4 LT   3  G:3438",
+        "Valuation": "12914",
+        "formatted_address": "17401 Spain Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -10406,21 +8866,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-3203",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "12/31/20",
-          "year": "2020",
-          "Address": "1355 WEST RIVER, Anchorage, Alaska",
-          "Parcel": "7803118000",
-          "Units": "0",
-          "Legal": "SOUTHFORK WEST BLK   4 LT   6  G:1059",
-          "Valuation": "26726",
-          "formatted_address": "1355 W River Dr, Eagle River, AK 99577, USA",
-          "lat": "61.2330473",
-          "lng": "-149.4548974"
-        }
+        "Permit": "R20-3203",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "12/31/20",
+        "year": "2020",
+        "Address": "1355 WEST RIVER, Anchorage, Alaska",
+        "Parcel": "7803118000",
+        "Units": "0",
+        "Legal": "SOUTHFORK WEST BLK   4 LT   6  G:1059",
+        "Valuation": "26726",
+        "formatted_address": "1355 W River Dr, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -10433,21 +8889,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-3204",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "12/31/20",
-          "year": "2020",
-          "Address": "3743 COVENTRY, Anchorage, Alaska",
-          "Parcel": "1423334000",
-          "Units": "0",
-          "Legal": "WINCHESTER HEIGHTS BLK   4 LT  12  G:2235",
-          "Valuation": "16986",
-          "formatted_address": "3743 Coventry Dr, Anchorage, AK 99507, USA",
-          "lat": "61.14579550000001",
-          "lng": "-149.8128599"
-        }
+        "Permit": "R20-3204",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "12/31/20",
+        "year": "2020",
+        "Address": "3743 COVENTRY, Anchorage, Alaska",
+        "Parcel": "1423334000",
+        "Units": "0",
+        "Legal": "WINCHESTER HEIGHTS BLK   4 LT  12  G:2235",
+        "Valuation": "16986",
+        "formatted_address": "3743 Coventry Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -10460,21 +8912,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-3205",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "12/31/20",
-          "year": "2020",
-          "Address": "8816 ACADIA, Anchorage, Alaska",
-          "Parcel": "5092148000",
-          "Units": "0",
-          "Legal": "EAGLE POINTE PH 7 BLK   2 LT   2  G:0152",
-          "Valuation": "19272",
-          "formatted_address": "8816 Acadia Dr, Eagle River, AK 99577, USA",
-          "lat": "61.30031899999999",
-          "lng": "-149.5685534"
-        }
+        "Permit": "R20-3205",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "12/31/20",
+        "year": "2020",
+        "Address": "8816 ACADIA, Anchorage, Alaska",
+        "Parcel": "5092148000",
+        "Units": "0",
+        "Legal": "EAGLE POINTE PH 7 BLK   2 LT   2  G:0152",
+        "Valuation": "19272",
+        "formatted_address": "8816 Acadia Dr, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -10487,21 +8935,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C21-1069",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "1/31/21",
-          "year": "2021",
-          "Address": "4303 FLORINA, Anchorage, Alaska",
-          "Parcel": "802401000",
-          "Units": "0",
-          "Legal": "ATHENIAN VILLAGE TR   G1  G:1735",
-          "Valuation": "84000",
-          "formatted_address": "4303 Florina St, Anchorage, AK 99508, USA",
-          "lat": "61.1816397",
-          "lng": "-149.8120312"
-        }
+        "Permit": "C21-1069",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "1/31/21",
+        "year": "2021",
+        "Address": "4303 FLORINA, Anchorage, Alaska",
+        "Parcel": "802401000",
+        "Units": "0",
+        "Legal": "ATHENIAN VILLAGE TR   G1  G:1735",
+        "Valuation": "84000",
+        "formatted_address": "4303 Florina St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -10514,21 +8958,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1031",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "1/31/21",
-          "year": "2021",
-          "Address": "2401 CAPTAIN COOK, Anchorage, Alaska",
-          "Parcel": "123527000",
-          "Units": "0",
-          "Legal": "TURNAGAIN HOMES BLK   E LT  20A  G:1527",
-          "Valuation": "10499.99",
-          "formatted_address": "2401 Captain Cook Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1988314",
-          "lng": "-149.9388171"
-        }
+        "Permit": "R21-1031",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "1/31/21",
+        "year": "2021",
+        "Address": "2401 CAPTAIN COOK, Anchorage, Alaska",
+        "Parcel": "123527000",
+        "Units": "0",
+        "Legal": "TURNAGAIN HOMES BLK   E LT  20A  G:1527",
+        "Valuation": "10499.99",
+        "formatted_address": "2401 Captain Cook Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -10541,21 +8981,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1032",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "1/31/21",
-          "year": "2021",
-          "Address": "8051 WILLIWA, Anchorage, Alaska",
-          "Parcel": "704371000",
-          "Units": "0",
-          "Legal": "PLEASANT VALLEY BLK  12 LT  20  G:1641",
-          "Valuation": "19606.149999999998",
-          "formatted_address": "8051 Williwa Ave, Anchorage, AK 99504, USA",
-          "lat": "61.18930520000001",
-          "lng": "-149.7299707"
-        }
+        "Permit": "R21-1032",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "1/31/21",
+        "year": "2021",
+        "Address": "8051 WILLIWA, Anchorage, Alaska",
+        "Parcel": "704371000",
+        "Units": "0",
+        "Legal": "PLEASANT VALLEY BLK  12 LT  20  G:1641",
+        "Valuation": "19606.149999999998",
+        "formatted_address": "8051 Williwa Ave, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -10568,21 +9004,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1033",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "1/31/21",
-          "year": "2021",
-          "Address": "5052 MILLS DRIVE, Anchorage, Alaska",
-          "Parcel": "512172000",
-          "Units": "0",
-          "Legal": "COLLEGEGATE #4 BLK  10 LT  16  G:1637",
-          "Valuation": "19606.149999999998",
-          "formatted_address": "5052 Mills Dr, Anchorage, AK 99508, USA",
-          "lat": "61.19146490000001",
-          "lng": "-149.7867362"
-        }
+        "Permit": "R21-1033",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "1/31/21",
+        "year": "2021",
+        "Address": "5052 MILLS DRIVE, Anchorage, Alaska",
+        "Parcel": "512172000",
+        "Units": "0",
+        "Legal": "COLLEGEGATE #4 BLK  10 LT  16  G:1637",
+        "Valuation": "19606.149999999998",
+        "formatted_address": "5052 Mills Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -10595,21 +9027,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1035",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "1/31/21",
-          "year": "2021",
-          "Address": "3970 ALITAK BAY, Anchorage, Alaska",
-          "Parcel": "1909132000",
-          "Units": "0",
-          "Legal": "BAYSHORE WEST #2 BLK   3 LT  13  G:2626",
-          "Valuation": "5590",
-          "formatted_address": "3970 Alitak Bay Cir, Anchorage, AK 99515, USA",
-          "lat": "61.1207775",
-          "lng": "-149.9483857"
-        }
+        "Permit": "R21-1035",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "1/31/21",
+        "year": "2021",
+        "Address": "3970 ALITAK BAY, Anchorage, Alaska",
+        "Parcel": "1909132000",
+        "Units": "0",
+        "Legal": "BAYSHORE WEST #2 BLK   3 LT  13  G:2626",
+        "Valuation": "5590",
+        "formatted_address": "3970 Alitak Bay Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -10622,21 +9050,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1050",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "1/31/21",
-          "year": "2021",
-          "Address": "8600 JUPITER, Anchorage, Alaska",
-          "Parcel": "1501223000",
-          "Units": "0",
-          "Legal": "ZODIAK MANOR ALASKA BLK   5 LT  26  G:2336",
-          "Valuation": "15721",
-          "formatted_address": "8600 Jupiter Dr, Anchorage, AK 99507, USA",
-          "lat": "61.14271519999999",
-          "lng": "-149.7980814"
-        }
+        "Permit": "R21-1050",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "1/31/21",
+        "year": "2021",
+        "Address": "8600 JUPITER, Anchorage, Alaska",
+        "Parcel": "1501223000",
+        "Units": "0",
+        "Legal": "ZODIAK MANOR ALASKA BLK   5 LT  26  G:2336",
+        "Valuation": "15721",
+        "formatted_address": "8600 Jupiter Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -10649,21 +9073,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1051",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "1/31/21",
-          "year": "2021",
-          "Address": "2956 GLADYS MARIE, Anchorage, Alaska",
-          "Parcel": "1553412000",
-          "Units": "0",
-          "Legal": "THE TERRACES PH 3 BLK   4 LT  79  G:2634",
-          "Valuation": "18691",
-          "formatted_address": "2956 Gladys Marie Cir, Anchorage, AK 99516, USA",
-          "lat": "61.1173687",
-          "lng": "-149.8273392"
-        }
+        "Permit": "R21-1051",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "1/31/21",
+        "year": "2021",
+        "Address": "2956 GLADYS MARIE, Anchorage, Alaska",
+        "Parcel": "1553412000",
+        "Units": "0",
+        "Legal": "THE TERRACES PH 3 BLK   4 LT  79  G:2634",
+        "Valuation": "18691",
+        "formatted_address": "2956 Gladys Marie Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -10676,21 +9096,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1069",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "1/31/21",
-          "year": "2021",
-          "Address": "3761 CHINIAK BAY, Anchorage, Alaska",
-          "Parcel": "1140109000",
-          "Units": "0",
-          "Legal": "BAYSHORE WEST #2 BLK   5 LT   8  G:2525",
-          "Valuation": "16000",
-          "formatted_address": "3761 Chiniak Bay Dr, Anchorage, AK 99515, USA",
-          "lat": "61.1234019",
-          "lng": "-149.9517931"
-        }
+        "Permit": "R21-1069",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "1/31/21",
+        "year": "2021",
+        "Address": "3761 CHINIAK BAY, Anchorage, Alaska",
+        "Parcel": "1140109000",
+        "Units": "0",
+        "Legal": "BAYSHORE WEST #2 BLK   5 LT   8  G:2525",
+        "Valuation": "16000",
+        "formatted_address": "3761 Chiniak Bay Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -10703,21 +9119,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1070",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "1/31/21",
-          "year": "2021",
-          "Address": "12921 MONTEREY, Anchorage, Alaska",
-          "Parcel": "1735357000",
-          "Units": "0",
-          "Legal": "KEMPTON HILLS #3 BLK   4 LT  62  G:2834",
-          "Valuation": "15000",
-          "formatted_address": "12921 Monterey Cir, Anchorage, AK 99516, USA",
-          "lat": "61.1034165",
-          "lng": "-149.8270939"
-        }
+        "Permit": "R21-1070",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "1/31/21",
+        "year": "2021",
+        "Address": "12921 MONTEREY, Anchorage, Alaska",
+        "Parcel": "1735357000",
+        "Units": "0",
+        "Legal": "KEMPTON HILLS #3 BLK   4 LT  62  G:2834",
+        "Valuation": "15000",
+        "formatted_address": "12921 Monterey Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -10730,21 +9142,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1071",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "1/31/21",
-          "year": "2021",
-          "Address": "W 3302 81ST, Anchorage, Alaska",
-          "Parcel": "1225317000",
-          "Units": "0",
-          "Legal": "SHADY BIRCH BLK   3 LT   4  G:2226",
-          "Valuation": "25000",
-          "formatted_address": "3302 W 81st Ave, Anchorage, AK 99502, USA",
-          "lat": "61.14722279999999",
-          "lng": "-149.9408865"
-        }
+        "Permit": "R21-1071",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "1/31/21",
+        "year": "2021",
+        "Address": "W 3302 81ST, Anchorage, Alaska",
+        "Parcel": "1225317000",
+        "Units": "0",
+        "Legal": "SHADY BIRCH BLK   3 LT   4  G:2226",
+        "Valuation": "25000",
+        "formatted_address": "3302 W 81st Ave, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -10757,21 +9165,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1072",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "1/31/21",
-          "year": "2021",
-          "Address": "10342 PRINCE WILLIAM CIRCLE, Anchorage, Alaska",
-          "Parcel": "1140281000",
-          "Units": "0",
-          "Legal": "RESOLUTION POINTE PH 1 BLK  3A LT  17  G:2525",
-          "Valuation": "37000",
-          "formatted_address": "10342 Prince William Cir, Anchorage, AK 99515, USA",
-          "lat": "61.12664179999999",
-          "lng": "-149.9586789"
-        }
+        "Permit": "R21-1072",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "1/31/21",
+        "year": "2021",
+        "Address": "10342 PRINCE WILLIAM CIRCLE, Anchorage, Alaska",
+        "Parcel": "1140281000",
+        "Units": "0",
+        "Legal": "RESOLUTION POINTE PH 1 BLK  3A LT  17  G:2525",
+        "Valuation": "37000",
+        "formatted_address": "10342 Prince William Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -10784,21 +9188,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1095",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2/28/21",
-          "year": "2021",
-          "Address": "2211 CHANDALAR, Anchorage, Alaska",
-          "Parcel": "635309000",
-          "Units": "0",
-          "Legal": "CHESTER HEIGHTS BLK   2 LT  38  G:1540",
-          "Valuation": "19880",
-          "formatted_address": "2211 Chandalar Dr, Anchorage, AK 99504, USA",
-          "lat": "61.2004683",
-          "lng": "-149.7436585"
-        }
+        "Permit": "R21-1095",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2/28/21",
+        "year": "2021",
+        "Address": "2211 CHANDALAR, Anchorage, Alaska",
+        "Parcel": "635309000",
+        "Units": "0",
+        "Legal": "CHESTER HEIGHTS BLK   2 LT  38  G:1540",
+        "Valuation": "19880",
+        "formatted_address": "2211 Chandalar Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -10811,21 +9211,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1139",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2/28/21",
-          "year": "2021",
-          "Address": "2417 TULIK, Anchorage, Alaska",
-          "Parcel": "122411000",
-          "Units": "0",
-          "Legal": "SIMONSON ESTATE BLK   A LT   7 PLAT 48-B G:1526",
-          "Valuation": "18000",
-          "formatted_address": "2417 Tulik Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1985757",
-          "lng": "-149.9515809"
-        }
+        "Permit": "R21-1139",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2/28/21",
+        "year": "2021",
+        "Address": "2417 TULIK, Anchorage, Alaska",
+        "Parcel": "122411000",
+        "Units": "0",
+        "Legal": "SIMONSON ESTATE BLK   A LT   7 PLAT 48-B G:1526",
+        "Valuation": "18000",
+        "formatted_address": "2417 Tulik Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -10838,21 +9234,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1140",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "2/28/21",
-          "year": "2021",
-          "Address": "7541 CHAD, Anchorage, Alaska",
-          "Parcel": "1217501000",
-          "Units": "0",
-          "Legal": "SHERWOOD ACRES BLK   3 LT  14  G:2129",
-          "Valuation": "20000",
-          "formatted_address": "7541 Chad St, Anchorage, AK 99518, USA",
-          "lat": "61.1521975",
-          "lng": "-149.9042125"
-        }
+        "Permit": "R21-1140",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "2/28/21",
+        "year": "2021",
+        "Address": "7541 CHAD, Anchorage, Alaska",
+        "Parcel": "1217501000",
+        "Units": "0",
+        "Legal": "SHERWOOD ACRES BLK   3 LT  14  G:2129",
+        "Valuation": "20000",
+        "formatted_address": "7541 Chad St, Anchorage, AK 99518, USA"
       }
     },
     {
@@ -10865,21 +9257,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1149",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/21",
-          "year": "2021",
-          "Address": "3344 BEAR RIDGE, Anchorage, Alaska",
-          "Parcel": "6762116000",
-          "Units": "0",
-          "Legal": "BEAR RIDGE LT  10  G:0804",
-          "Valuation": "17927",
-          "formatted_address": "3344 Bear Ridge Cir, Eagle River, AK 99577, USA",
-          "lat": "61.2505763",
-          "lng": "-149.2990342"
-        }
+        "Permit": "R21-1149",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/21",
+        "year": "2021",
+        "Address": "3344 BEAR RIDGE, Anchorage, Alaska",
+        "Parcel": "6762116000",
+        "Units": "0",
+        "Legal": "BEAR RIDGE LT  10  G:0804",
+        "Valuation": "17927",
+        "formatted_address": "3344 Bear Ridge Cir, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -10892,21 +9280,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1150",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/21",
-          "year": "2021",
-          "Address": "13418 STEPHENSON, Anchorage, Alaska",
-          "Parcel": "1811212000",
-          "Units": "0",
-          "Legal": "STATE MANOR LT  87  G:2933",
-          "Valuation": "10235",
-          "formatted_address": "13418 Stephenson St, Anchorage, AK 99515, USA",
-          "lat": "61.099249",
-          "lng": "-149.8447435"
-        }
+        "Permit": "R21-1150",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/21",
+        "year": "2021",
+        "Address": "13418 STEPHENSON, Anchorage, Alaska",
+        "Parcel": "1811212000",
+        "Units": "0",
+        "Legal": "STATE MANOR LT  87  G:2933",
+        "Valuation": "10235",
+        "formatted_address": "13418 Stephenson St, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -10919,21 +9303,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1151",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/21",
-          "year": "2021",
-          "Address": "W 912 21ST, Anchorage, Alaska",
-          "Parcel": "116330000",
-          "Units": "0",
-          "Legal": "KAPINGEN LT  19A  G:1529",
-          "Valuation": "18415",
-          "formatted_address": "912 W 21st Ave, Anchorage, AK 99503, USA",
-          "lat": "61.20168439999999",
-          "lng": "-149.8998181"
-        }
+        "Permit": "R21-1151",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/21",
+        "year": "2021",
+        "Address": "W 912 21ST, Anchorage, Alaska",
+        "Parcel": "116330000",
+        "Units": "0",
+        "Legal": "KAPINGEN LT  19A  G:1529",
+        "Valuation": "18415",
+        "formatted_address": "912 W 21st Ave, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -10946,21 +9326,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1152",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/21",
-          "year": "2021",
-          "Address": "3608 OREGON, Anchorage, Alaska",
-          "Parcel": "1012426000",
-          "Units": "0",
-          "Legal": "CONROY RUSHTON BLK   3 LT 5  G:1728",
-          "Valuation": "13928",
-          "formatted_address": "3608 Oregon Dr, Anchorage, AK 99517, USA",
-          "lat": "61.18714800000001",
-          "lng": "-149.9184231"
-        }
+        "Permit": "R21-1152",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/21",
+        "year": "2021",
+        "Address": "3608 OREGON, Anchorage, Alaska",
+        "Parcel": "1012426000",
+        "Units": "0",
+        "Legal": "CONROY RUSHTON BLK   3 LT 5  G:1728",
+        "Valuation": "13928",
+        "formatted_address": "3608 Oregon Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -10973,21 +9349,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1226",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "3/31/21",
-          "year": "2021",
-          "Address": "3940 TWILIGHT LANE, Anchorage, Alaska",
-          "Parcel": "1828122000",
-          "Units": "0",
-          "Legal": "T12N R3W SEC 33 LT 131B  G:3135",
-          "Valuation": "23232",
-          "formatted_address": "3940 Twilight Ln, Anchorage, AK 99516, USA",
-          "lat": "61.08673280000001",
-          "lng": "-149.8083516"
-        }
+        "Permit": "R21-1226",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "3/31/21",
+        "year": "2021",
+        "Address": "3940 TWILIGHT LANE, Anchorage, Alaska",
+        "Parcel": "1828122000",
+        "Units": "0",
+        "Legal": "T12N R3W SEC 33 LT 131B  G:3135",
+        "Valuation": "23232",
+        "formatted_address": "3940 Twilight Ln, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -11000,21 +9372,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1284",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/21",
-          "year": "2021",
-          "Address": "2781 SEAFARER, Anchorage, Alaska",
-          "Parcel": "1839166000",
-          "Units": "0",
-          "Legal": "TURNAGAIN VIEW #6 BLK  12 LT   9  G:2934",
-          "Valuation": "14918",
-          "formatted_address": "2781 Seafarer Loop, Anchorage, AK 99516, USA",
-          "lat": "61.0957746",
-          "lng": "-149.8317113"
-        }
+        "Permit": "R21-1284",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/21",
+        "year": "2021",
+        "Address": "2781 SEAFARER, Anchorage, Alaska",
+        "Parcel": "1839166000",
+        "Units": "0",
+        "Legal": "TURNAGAIN VIEW #6 BLK  12 LT   9  G:2934",
+        "Valuation": "14918",
+        "formatted_address": "2781 Seafarer Loop, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -11027,21 +9395,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1285",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/21",
-          "year": "2021",
-          "Address": "8651 SWISS PLACE, Anchorage, Alaska",
-          "Parcel": "1425203000",
-          "Units": "0",
-          "Legal": "SWISS AIRE LT  12  G:2334",
-          "Valuation": "21293",
-          "formatted_address": "8651 Swiss Pl, Anchorage, AK 99507, USA",
-          "lat": "61.14172910000001",
-          "lng": "-149.8272505"
-        }
+        "Permit": "R21-1285",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/21",
+        "year": "2021",
+        "Address": "8651 SWISS PLACE, Anchorage, Alaska",
+        "Parcel": "1425203000",
+        "Units": "0",
+        "Legal": "SWISS AIRE LT  12  G:2334",
+        "Valuation": "21293",
+        "formatted_address": "8651 Swiss Pl, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -11054,21 +9418,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1286",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/21",
-          "year": "2021",
-          "Address": "601 HILAND, Anchorage, Alaska",
-          "Parcel": "7827103000",
-          "Units": "0",
-          "Legal": "HUNDRED HILLS 1ST ADDITION BLK   6 LT   2  G:1161",
-          "Valuation": "27333",
-          "formatted_address": "601 Hiland Rd, Eagle River, AK 99577, USA",
-          "lat": "61.2255268",
-          "lng": "-149.4322122"
-        }
+        "Permit": "R21-1286",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/21",
+        "year": "2021",
+        "Address": "601 HILAND, Anchorage, Alaska",
+        "Parcel": "7827103000",
+        "Units": "0",
+        "Legal": "HUNDRED HILLS 1ST ADDITION BLK   6 LT   2  G:1161",
+        "Valuation": "27333",
+        "formatted_address": "601 Hiland Rd, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -11081,21 +9441,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1287",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/21",
-          "year": "2021",
-          "Address": "21812 SHEPPARD, Anchorage, Alaska",
-          "Parcel": "5020222000",
-          "Units": "0",
-          "Legal": "BLUEBERRY HILL BLK   1 LT   4  G:0058",
-          "Valuation": "28937",
-          "formatted_address": "21812 Sheppard Dr, Eagle River, AK 99577, USA",
-          "lat": "61.3148368",
-          "lng": "-149.4758113"
-        }
+        "Permit": "R21-1287",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/21",
+        "year": "2021",
+        "Address": "21812 SHEPPARD, Anchorage, Alaska",
+        "Parcel": "5020222000",
+        "Units": "0",
+        "Legal": "BLUEBERRY HILL BLK   1 LT   4  G:0058",
+        "Valuation": "28937",
+        "formatted_address": "21812 Sheppard Dr, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -11108,21 +9464,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1288",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/21",
-          "year": "2021",
-          "Address": "18548 OUTLOOK, Anchorage, Alaska",
-          "Parcel": "5031527000",
-          "Units": "0",
-          "Legal": "ROSEBERRY PARK ESTATES BLK   1 LT   2  G:0154",
-          "Valuation": "35721",
-          "formatted_address": "Anchorage, AK, USA",
-          "lat": "61.2175758",
-          "lng": "-149.8996785"
-        }
+        "Permit": "R21-1288",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/21",
+        "year": "2021",
+        "Address": "18548 OUTLOOK, Anchorage, Alaska",
+        "Parcel": "5031527000",
+        "Units": "0",
+        "Legal": "ROSEBERRY PARK ESTATES BLK   1 LT   2  G:0154",
+        "Valuation": "35721",
+        "formatted_address": "Anchorage, AK, USA"
       }
     },
     {
@@ -11135,21 +9487,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1393",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/21",
-          "year": "2021",
-          "Address": "3744 KNIK, Anchorage, Alaska",
-          "Parcel": "122545000",
-          "Units": "0",
-          "Legal": "SIMONSON BLK  16A LT   2  G:1526",
-          "Valuation": "21000",
-          "formatted_address": "3744 Knik Ave, Anchorage, AK 99517, USA",
-          "lat": "61.19646359999999",
-          "lng": "-149.9555089"
-        }
+        "Permit": "R21-1393",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/21",
+        "year": "2021",
+        "Address": "3744 KNIK, Anchorage, Alaska",
+        "Parcel": "122545000",
+        "Units": "0",
+        "Legal": "SIMONSON BLK  16A LT   2  G:1526",
+        "Valuation": "21000",
+        "formatted_address": "3744 Knik Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -11162,21 +9510,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1397",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/21",
-          "year": "2021",
-          "Address": "247 TANNER CIRCLE, Anchorage, Alaska",
-          "Parcel": "7516331000",
-          "Units": "0",
-          "Legal": "ALPINE VIEW ESTATES PH 2 BLK   1 LT  26  G:4815",
-          "Valuation": "27650",
-          "formatted_address": "247 Tanner Cir, Girdwood, AK 99587, USA",
-          "lat": "60.95898199999999",
-          "lng": "-149.1270005"
-        }
+        "Permit": "R21-1397",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/21",
+        "year": "2021",
+        "Address": "247 TANNER CIRCLE, Anchorage, Alaska",
+        "Parcel": "7516331000",
+        "Units": "0",
+        "Legal": "ALPINE VIEW ESTATES PH 2 BLK   1 LT  26  G:4815",
+        "Valuation": "27650",
+        "formatted_address": "247 Tanner Cir, Girdwood, AK 99587, USA"
       }
     },
     {
@@ -11189,21 +9533,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1398",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/21",
-          "year": "2021",
-          "Address": "159 CERVIN, Anchorage, Alaska",
-          "Parcel": "7607215000",
-          "Units": "0",
-          "Legal": "ALYESKA BASIN #5 BLK  20 LT   5  G:4916",
-          "Valuation": "16422",
-          "formatted_address": "159 Cervin Cir, Girdwood, AK 99587, USA",
-          "lat": "60.9555149",
-          "lng": "-149.1199136"
-        }
+        "Permit": "R21-1398",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/21",
+        "year": "2021",
+        "Address": "159 CERVIN, Anchorage, Alaska",
+        "Parcel": "7607215000",
+        "Units": "0",
+        "Legal": "ALYESKA BASIN #5 BLK  20 LT   5  G:4916",
+        "Valuation": "16422",
+        "formatted_address": "159 Cervin Cir, Girdwood, AK 99587, USA"
       }
     },
     {
@@ -11216,21 +9556,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1399",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/21",
-          "year": "2021",
-          "Address": "10372 RIDGE PARK, Anchorage, Alaska",
-          "Parcel": "1623546000",
-          "Units": "0",
-          "Legal": "RIDGEMONT BLK   3 LT   9  G:2533",
-          "Valuation": "14492",
-          "formatted_address": "10372 Ridge Park Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1269582",
-          "lng": "-149.8382478"
-        }
+        "Permit": "R21-1399",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/21",
+        "year": "2021",
+        "Address": "10372 RIDGE PARK, Anchorage, Alaska",
+        "Parcel": "1623546000",
+        "Units": "0",
+        "Legal": "RIDGEMONT BLK   3 LT   9  G:2533",
+        "Valuation": "14492",
+        "formatted_address": "10372 Ridge Park Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -11243,21 +9579,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1401",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/21",
-          "year": "2021",
-          "Address": "3240 SOUTH, Anchorage, Alaska",
-          "Parcel": "1430291000",
-          "Units": "0",
-          "Legal": "GRAZELDA BLK   2 LT  23  G:2334",
-          "Valuation": "3500",
-          "formatted_address": "11124 Old Seward Hwy, Anchorage, AK 99515, USA",
-          "lat": "61.1199527",
-          "lng": "-149.8678209"
-        }
+        "Permit": "R21-1401",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/21",
+        "year": "2021",
+        "Address": "3240 SOUTH, Anchorage, Alaska",
+        "Parcel": "1430291000",
+        "Units": "0",
+        "Legal": "GRAZELDA BLK   2 LT  23  G:2334",
+        "Valuation": "3500",
+        "formatted_address": "11124 Old Seward Hwy, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -11270,21 +9602,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1446",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/21",
-          "year": "2021",
-          "Address": "3310 JERDE, Anchorage, Alaska",
-          "Parcel": "702105000",
-          "Units": "0",
-          "Legal": "JERDE WOOD BLK   1 LT   4  G:1638",
-          "Valuation": "21000",
-          "formatted_address": "3310 Jerde Cir, Anchorage, AK 99504, USA",
-          "lat": "61.19061749999999",
-          "lng": "-149.7643712"
-        }
+        "Permit": "R21-1446",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/21",
+        "year": "2021",
+        "Address": "3310 JERDE, Anchorage, Alaska",
+        "Parcel": "702105000",
+        "Units": "0",
+        "Legal": "JERDE WOOD BLK   1 LT   4  G:1638",
+        "Valuation": "21000",
+        "formatted_address": "3310 Jerde Cir, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -11297,21 +9625,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1448",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/21",
-          "year": "2021",
-          "Address": "2500 LORD BARANOF, Anchorage, Alaska",
-          "Parcel": "123508000",
-          "Units": "0",
-          "Legal": "TURNAGAIN HOMES BLK   E LT   7  G:1527",
-          "Valuation": "28000",
-          "formatted_address": "2500 Lord Baranof Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19781049999999",
-          "lng": "-149.9369062"
-        }
+        "Permit": "R21-1448",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/21",
+        "year": "2021",
+        "Address": "2500 LORD BARANOF, Anchorage, Alaska",
+        "Parcel": "123508000",
+        "Units": "0",
+        "Legal": "TURNAGAIN HOMES BLK   E LT   7  G:1527",
+        "Valuation": "28000",
+        "formatted_address": "2500 Lord Baranof Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -11324,21 +9648,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1529",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/21",
-          "year": "2021",
-          "Address": "3212 TAYSHEE, Anchorage, Alaska",
-          "Parcel": "718110000",
-          "Units": "0",
-          "Legal": "BARANOF WOODS BLK   3 LT  33A  G:1639",
-          "Valuation": "11500",
-          "formatted_address": "3212 Tayshee Cir, Anchorage, AK 99504, USA",
-          "lat": "61.1914645",
-          "lng": "-149.755572"
-        }
+        "Permit": "R21-1529",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/21",
+        "year": "2021",
+        "Address": "3212 TAYSHEE, Anchorage, Alaska",
+        "Parcel": "718110000",
+        "Units": "0",
+        "Legal": "BARANOF WOODS BLK   3 LT  33A  G:1639",
+        "Valuation": "11500",
+        "formatted_address": "3212 Tayshee Cir, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -11351,21 +9671,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1629",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/21",
-          "year": "2021",
-          "Address": "2131 LORD BARANOF, Anchorage, Alaska",
-          "Parcel": "118328000",
-          "Units": "0",
-          "Legal": "TURNAGAIN HOMES BLK   D LT  45  G:1527",
-          "Valuation": "16593",
-          "formatted_address": "2131 Lord Baranof Dr, Anchorage, AK 99517, USA",
-          "lat": "61.2009933",
-          "lng": "-149.9391122"
-        }
+        "Permit": "R21-1629",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/21",
+        "year": "2021",
+        "Address": "2131 LORD BARANOF, Anchorage, Alaska",
+        "Parcel": "118328000",
+        "Units": "0",
+        "Legal": "TURNAGAIN HOMES BLK   D LT  45  G:1527",
+        "Valuation": "16593",
+        "formatted_address": "2131 Lord Baranof Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -11378,21 +9694,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1630",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/21",
-          "year": "2021",
-          "Address": "1500 CACHE DRIVE, Anchorage, Alaska",
-          "Parcel": "919256000",
-          "Units": "0",
-          "Legal": "WICKERSHAM PARK #5 BLK   6 LT   7  G:1833",
-          "Valuation": "15802",
-          "formatted_address": "1500 Cache Dr, Anchorage, AK 99507, USA",
-          "lat": "61.17672459999999",
-          "lng": "-149.8528419"
-        }
+        "Permit": "R21-1630",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/21",
+        "year": "2021",
+        "Address": "1500 CACHE DRIVE, Anchorage, Alaska",
+        "Parcel": "919256000",
+        "Units": "0",
+        "Legal": "WICKERSHAM PARK #5 BLK   6 LT   7  G:1833",
+        "Valuation": "15802",
+        "formatted_address": "1500 Cache Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -11405,21 +9717,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1631",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/21",
-          "year": "2021",
-          "Address": "7284 TYRE, Anchorage, Alaska",
-          "Parcel": "1142266000",
-          "Units": "0",
-          "Legal": "MUIRWOOD PARK BLK   3 LT  17  G:2123",
-          "Valuation": "21090",
-          "formatted_address": "7284 Tyre Dr, Anchorage, AK 99502, USA",
-          "lat": "61.1547813",
-          "lng": "-149.9932214"
-        }
+        "Permit": "R21-1631",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/21",
+        "year": "2021",
+        "Address": "7284 TYRE, Anchorage, Alaska",
+        "Parcel": "1142266000",
+        "Units": "0",
+        "Legal": "MUIRWOOD PARK BLK   3 LT  17  G:2123",
+        "Valuation": "21090",
+        "formatted_address": "7284 Tyre Dr, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -11432,21 +9740,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1632",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/21",
-          "year": "2021",
-          "Address": "E 8100 11TH, Anchorage, Alaska",
-          "Parcel": "612237000",
-          "Units": "0",
-          "Legal": "MULDOON HEIGHTS BLK   2 LT  12  G:1341",
-          "Valuation": "22466",
-          "formatted_address": "8100 E 11th Ct, Anchorage, AK 99504, USA",
-          "lat": "61.2122195",
-          "lng": "-149.7288159"
-        }
+        "Permit": "R21-1632",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/21",
+        "year": "2021",
+        "Address": "E 8100 11TH, Anchorage, Alaska",
+        "Parcel": "612237000",
+        "Units": "0",
+        "Legal": "MULDOON HEIGHTS BLK   2 LT  12  G:1341",
+        "Valuation": "22466",
+        "formatted_address": "8100 E 11th Ct, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -11459,21 +9763,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1633",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/21",
-          "year": "2021",
-          "Address": "10840 VOSIKOF, Anchorage, Alaska",
-          "Parcel": "1516419000",
-          "Units": "0",
-          "Legal": "TIMBERLINE LT   9  G:2641",
-          "Valuation": "28781",
-          "formatted_address": "10840 Vosikof Pl, Anchorage, AK 99507, USA",
-          "lat": "61.1225119",
-          "lng": "-149.7265311"
-        }
+        "Permit": "R21-1633",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/21",
+        "year": "2021",
+        "Address": "10840 VOSIKOF, Anchorage, Alaska",
+        "Parcel": "1516419000",
+        "Units": "0",
+        "Legal": "TIMBERLINE LT   9  G:2641",
+        "Valuation": "28781",
+        "formatted_address": "10840 Vosikof Pl, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -11486,21 +9786,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1634",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/21",
-          "year": "2021",
-          "Address": "4019 KOGRU, Anchorage, Alaska",
-          "Parcel": "5058120000",
-          "Units": "0",
-          "Legal": "NORTH SLOPE #2 BLK   5 LT  16  G:0703",
-          "Valuation": "15268",
-          "formatted_address": "4019 Kogru Pl, Eagle River, AK 99577, USA",
-          "lat": "61.2568125",
-          "lng": "-149.3142444"
-        }
+        "Permit": "R21-1634",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/21",
+        "year": "2021",
+        "Address": "4019 KOGRU, Anchorage, Alaska",
+        "Parcel": "5058120000",
+        "Units": "0",
+        "Legal": "NORTH SLOPE #2 BLK   5 LT  16  G:0703",
+        "Valuation": "15268",
+        "formatted_address": "4019 Kogru Pl, Eagle River, AK 99577, USA"
       }
     },
     {
@@ -11513,21 +9809,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1742",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/21",
-          "year": "2021",
-          "Address": "7831 CASEY CIRCLE, Anchorage, Alaska",
-          "Parcel": "1416155000",
-          "Units": "0",
-          "Legal": "BIG FOOT LT   9  G:2235",
-          "Valuation": "11000",
-          "formatted_address": "7831 Casey Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1496146",
-          "lng": "-149.8083435"
-        }
+        "Permit": "R21-1742",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/21",
+        "year": "2021",
+        "Address": "7831 CASEY CIRCLE, Anchorage, Alaska",
+        "Parcel": "1416155000",
+        "Units": "0",
+        "Legal": "BIG FOOT LT   9  G:2235",
+        "Valuation": "11000",
+        "formatted_address": "7831 Casey Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -11540,21 +9832,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1743",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/21",
-          "year": "2021",
-          "Address": "12421 HACE, Anchorage, Alaska",
-          "Parcel": "1802139000",
-          "Units": "0",
-          "Legal": "BEACON PARK BLK   2 LT   3  G:2832",
-          "Valuation": "21000",
-          "formatted_address": "12421 Hace St, Anchorage, AK 99515, USA",
-          "lat": "61.1080584",
-          "lng": "-149.8540051"
-        }
+        "Permit": "R21-1743",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/21",
+        "year": "2021",
+        "Address": "12421 HACE, Anchorage, Alaska",
+        "Parcel": "1802139000",
+        "Units": "0",
+        "Legal": "BEACON PARK BLK   2 LT   3  G:2832",
+        "Valuation": "21000",
+        "formatted_address": "12421 Hace St, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -11567,21 +9855,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1919",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/21",
-          "year": "2021",
-          "Address": "611 LORI, Anchorage, Alaska",
-          "Parcel": "611508000",
-          "Units": "0",
-          "Legal": "KLUANE TERRACE TRAILER EST #4 BLK   3 LT   4  G:1341",
-          "Valuation": "34000",
-          "formatted_address": "611 Lori Dr, Anchorage, AK 99504, USA",
-          "lat": "61.21621549999999",
-          "lng": "-149.7194446"
-        }
+        "Permit": "R21-1919",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/21",
+        "year": "2021",
+        "Address": "611 LORI, Anchorage, Alaska",
+        "Parcel": "611508000",
+        "Units": "0",
+        "Legal": "KLUANE TERRACE TRAILER EST #4 BLK   3 LT   4  G:1341",
+        "Valuation": "34000",
+        "formatted_address": "611 Lori Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -11594,21 +9878,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1931",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/21",
-          "year": "2021",
-          "Address": "16906 OLD GLENN, Anchorage, Alaska",
-          "Parcel": "5126203000",
-          "Units": "0",
-          "Legal": "T15N R1W SEC 20 LT  28  G:0856",
-          "Valuation": "41744",
-          "formatted_address": "16906 Old Glenn Hwy, Chugiak, AK 99567, USA",
-          "lat": "61.3735667",
-          "lng": "-149.5086207"
-        }
+        "Permit": "R21-1931",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/21",
+        "year": "2021",
+        "Address": "16906 OLD GLENN, Anchorage, Alaska",
+        "Parcel": "5126203000",
+        "Units": "0",
+        "Legal": "T15N R1W SEC 20 LT  28  G:0856",
+        "Valuation": "41744",
+        "formatted_address": "16906 Old Glenn Hwy, Chugiak, AK 99567, USA"
       }
     },
     {
@@ -11621,21 +9901,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-1933",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/21",
-          "year": "2021",
-          "Address": "7704 CHAIMI, Anchorage, Alaska",
-          "Parcel": "712735000",
-          "Units": "0",
-          "Legal": "CHUGACH MOUNTAIN ESTATES BLK 9LT 9  G:1740",
-          "Valuation": "21414",
-          "formatted_address": "7704 Chaimi Loop, Anchorage, AK 99504, USA",
-          "lat": "61.1810111",
-          "lng": "-149.7362516"
-        }
+        "Permit": "R21-1933",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/21",
+        "year": "2021",
+        "Address": "7704 CHAIMI, Anchorage, Alaska",
+        "Parcel": "712735000",
+        "Units": "0",
+        "Legal": "CHUGACH MOUNTAIN ESTATES BLK 9LT 9  G:1740",
+        "Valuation": "21414",
+        "formatted_address": "7704 Chaimi Loop, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -11648,21 +9924,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2002",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/21",
-          "year": "2021",
-          "Address": "6061 BRISTOL, Anchorage, Alaska",
-          "Parcel": "1739145000",
-          "Units": "0",
-          "Legal": "MOUNTAIN PARK ESTATES BLK   9 LT  11  G:2838",
-          "Valuation": "23958",
-          "formatted_address": "6061 Bristol Dr, Anchorage, AK 99516, USA",
-          "lat": "61.10399539999999",
-          "lng": "-149.7687283"
-        }
+        "Permit": "R21-2002",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/21",
+        "year": "2021",
+        "Address": "6061 BRISTOL, Anchorage, Alaska",
+        "Parcel": "1739145000",
+        "Units": "0",
+        "Legal": "MOUNTAIN PARK ESTATES BLK   9 LT  11  G:2838",
+        "Valuation": "23958",
+        "formatted_address": "6061 Bristol Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -11675,21 +9947,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2059",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "6/30/21",
-          "year": "2021",
-          "Address": "W 2710 34TH, Anchorage, Alaska",
-          "Parcel": "1008212000",
-          "Units": "NA",
-          "Legal": "0   NEW MCRAE BLK   1 LT   5  G:1627",
-          "Valuation": "50572",
-          "formatted_address": "2710 W 34th Ave, Anchorage, AK 99517, USA",
-          "lat": "61.18961549999999",
-          "lng": "-149.9344865"
-        }
+        "Permit": "R21-2059",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "6/30/21",
+        "year": "2021",
+        "Address": "W 2710 34TH, Anchorage, Alaska",
+        "Parcel": "1008212000",
+        "Units": "NA",
+        "Legal": "0   NEW MCRAE BLK   1 LT   5  G:1627",
+        "Valuation": "50572",
+        "formatted_address": "2710 W 34th Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -11702,21 +9970,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2073",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "6/30/21",
-          "year": "2021",
-          "Address": "3860 REFLECTION DRIVE, Anchorage, Alaska",
-          "Parcel": "709166000",
-          "Units": "NA",
-          "Legal": "0   REFLECTION LAKE BLK   1 LT  20A  G:1738",
-          "Valuation": "20380",
-          "formatted_address": "3860 Reflection Dr, Anchorage, AK 99504, USA",
-          "lat": "61.18556319999999",
-          "lng": "-149.7751976"
-        }
+        "Permit": "R21-2073",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "6/30/21",
+        "year": "2021",
+        "Address": "3860 REFLECTION DRIVE, Anchorage, Alaska",
+        "Parcel": "709166000",
+        "Units": "NA",
+        "Legal": "0   REFLECTION LAKE BLK   1 LT  20A  G:1738",
+        "Valuation": "20380",
+        "formatted_address": "3860 Reflection Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -11729,21 +9993,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2098",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/21",
-          "year": "2021",
-          "Address": "1413 ATKINSON, Anchorage, Alaska",
-          "Parcel": "616741000",
-          "Units": "0",
-          "Legal": "NUNAKA VALLEY BLK   C LT  14  G:1438",
-          "Valuation": "17125.9",
-          "formatted_address": "1413 Atkinson Dr, Anchorage, AK 99504, USA",
-          "lat": "61.2081405",
-          "lng": "-149.7663279"
-        }
+        "Permit": "R21-2098",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/21",
+        "year": "2021",
+        "Address": "1413 ATKINSON, Anchorage, Alaska",
+        "Parcel": "616741000",
+        "Units": "0",
+        "Legal": "NUNAKA VALLEY BLK   C LT  14  G:1438",
+        "Valuation": "17125.9",
+        "formatted_address": "1413 Atkinson Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -11756,21 +10016,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2110",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/21",
-          "year": "2021",
-          "Address": "8677 ESTATES CIRCLE, Anchorage, Alaska",
-          "Parcel": "1424448000",
-          "Units": "0",
-          "Legal": "SPRUCE RIDGE ESTATES LT   3  G:2335",
-          "Valuation": "24533",
-          "formatted_address": "8677 Estates Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1427997",
-          "lng": "-149.8143731"
-        }
+        "Permit": "R21-2110",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/21",
+        "year": "2021",
+        "Address": "8677 ESTATES CIRCLE, Anchorage, Alaska",
+        "Parcel": "1424448000",
+        "Units": "0",
+        "Legal": "SPRUCE RIDGE ESTATES LT   3  G:2335",
+        "Valuation": "24533",
+        "formatted_address": "8677 Estates Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -11783,21 +10039,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2111",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/21",
-          "year": "2021",
-          "Address": "1070 NORTHPOINTE BLUFF, Anchorage, Alaska",
-          "Parcel": "302123000",
-          "Units": "0",
-          "Legal": "NORTHPOINTE BLUFF BLK   1 LT   9 NORTHPOINTE BLUFF PLANNED COMM G:1132",
-          "Valuation": "29754",
-          "formatted_address": "1070 Northpointe Bluff Dr, Anchorage, AK 99501, USA",
-          "lat": "61.22775290000001",
-          "lng": "-149.8649185"
-        }
+        "Permit": "R21-2111",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/21",
+        "year": "2021",
+        "Address": "1070 NORTHPOINTE BLUFF, Anchorage, Alaska",
+        "Parcel": "302123000",
+        "Units": "0",
+        "Legal": "NORTHPOINTE BLUFF BLK   1 LT   9 NORTHPOINTE BLUFF PLANNED COMM G:1132",
+        "Valuation": "29754",
+        "formatted_address": "1070 Northpointe Bluff Dr, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -11810,21 +10062,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2112",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/21",
-          "year": "2021",
-          "Address": "2010 BELMONT, Anchorage, Alaska",
-          "Parcel": "117347000",
-          "Units": "0",
-          "Legal": "HUNTINGTON PARK #5A BLK   8 LT  34  G:1528",
-          "Valuation": "17872",
-          "formatted_address": "2010 Belmont Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1991432",
-          "lng": "-149.9271118"
-        }
+        "Permit": "R21-2112",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/21",
+        "year": "2021",
+        "Address": "2010 BELMONT, Anchorage, Alaska",
+        "Parcel": "117347000",
+        "Units": "0",
+        "Legal": "HUNTINGTON PARK #5A BLK   8 LT  34  G:1528",
+        "Valuation": "17872",
+        "formatted_address": "2010 Belmont Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -11837,21 +10085,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2163",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "7/31/21",
-          "year": "2021",
-          "Address": "4902 DE ARMOUN, Anchorage, Alaska",
-          "Parcel": "1809250000",
-          "Units": "0",
-          "Legal": "W-A LT   2  G:2936",
-          "Valuation": "19600",
-          "formatted_address": "4902 De Armoun Rd, Anchorage, AK 99516, USA",
-          "lat": "61.0949492",
-          "lng": "-149.7900754"
-        }
+        "Permit": "R21-2163",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "7/31/21",
+        "year": "2021",
+        "Address": "4902 DE ARMOUN, Anchorage, Alaska",
+        "Parcel": "1809250000",
+        "Units": "0",
+        "Legal": "W-A LT   2  G:2936",
+        "Valuation": "19600",
+        "formatted_address": "4902 De Armoun Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -11864,21 +10108,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2187",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "7/31/21",
-          "year": "2021",
-          "Address": "10650 LONE TREE, Anchorage, Alaska",
-          "Parcel": "1532255000",
-          "Units": "0",
-          "Legal": "VALLI VUE ESTATES #2 BLK   2 LT   3  G:2538",
-          "Valuation": "6414",
-          "formatted_address": "10650 Lone Tree Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1237858",
-          "lng": "-149.7609118"
-        }
+        "Permit": "R21-2187",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "7/31/21",
+        "year": "2021",
+        "Address": "10650 LONE TREE, Anchorage, Alaska",
+        "Parcel": "1532255000",
+        "Units": "0",
+        "Legal": "VALLI VUE ESTATES #2 BLK   2 LT   3  G:2538",
+        "Valuation": "6414",
+        "formatted_address": "10650 Lone Tree Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -11891,21 +10131,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2240",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "7/31/21",
-          "year": "2021",
-          "Address": "2850 PELICAN DRIVE, Anchorage, Alaska",
-          "Parcel": "1238337000",
-          "Units": "0",
-          "Legal": "CAMPBELL LAKE HEIGHTS #10 BLK   2 LT  21  G:2427",
-          "Valuation": "20137",
-          "formatted_address": "2850 Pelican Dr, Anchorage, AK 99502, USA",
-          "lat": "61.1342405",
-          "lng": "-149.9347077"
-        }
+        "Permit": "R21-2240",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "7/31/21",
+        "year": "2021",
+        "Address": "2850 PELICAN DRIVE, Anchorage, Alaska",
+        "Parcel": "1238337000",
+        "Units": "0",
+        "Legal": "CAMPBELL LAKE HEIGHTS #10 BLK   2 LT  21  G:2427",
+        "Valuation": "20137",
+        "formatted_address": "2850 Pelican Dr, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -11918,21 +10154,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2241",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/21",
-          "year": "2021",
-          "Address": "5612 HERITAGE HEIGHTS, Anchorage, Alaska",
-          "Parcel": "1522176000",
-          "Units": "0",
-          "Legal": "CROSS VIEW ESTATES BLK   2 LT  14  G:2737",
-          "Valuation": "25404",
-          "formatted_address": "5612 Heritage Heights Dr, Anchorage, AK 99516, USA",
-          "lat": "61.11091039999999",
-          "lng": "-149.7822721"
-        }
+        "Permit": "R21-2241",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/21",
+        "year": "2021",
+        "Address": "5612 HERITAGE HEIGHTS, Anchorage, Alaska",
+        "Parcel": "1522176000",
+        "Units": "0",
+        "Legal": "CROSS VIEW ESTATES BLK   2 LT  14  G:2737",
+        "Valuation": "25404",
+        "formatted_address": "5612 Heritage Heights Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -11945,21 +10177,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C21-1815",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/30/21",
-          "year": "2021",
-          "Address": "1361 HUFFMAN PARK, Anchorage, Alaska",
-          "Parcel": "1619193024",
-          "Units": "0",
-          "Legal": "LUCKY HUFFMAN BLK 1 LT 3 THE GARAGE AT HUFFMAN G:2732",
-          "Valuation": "17136",
-          "formatted_address": "1361 Huffman Park Dr, Anchorage, AK 99515, USA",
-          "lat": "61.11078970000001",
-          "lng": "-149.8576419"
-        }
+        "Permit": "C21-1815",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/30/21",
+        "year": "2021",
+        "Address": "1361 HUFFMAN PARK, Anchorage, Alaska",
+        "Parcel": "1619193024",
+        "Units": "0",
+        "Legal": "LUCKY HUFFMAN BLK 1 LT 3 THE GARAGE AT HUFFMAN G:2732",
+        "Valuation": "17136",
+        "formatted_address": "1361 Huffman Park Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -11972,21 +10200,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2439",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "MIDNIGHT SUN SOLAR LLC",
-          "Date": "8/30/21",
-          "year": "2021",
-          "Address": "6101 GROSS DRIVE, Anchorage, Alaska",
-          "Parcel": "1492232000",
-          "Units": "0",
-          "Legal": "CHUGACH ESTATES BLK 2 LT 16B G:2034",
-          "Valuation": "24527",
-          "formatted_address": "6101 Gross Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1657097",
-          "lng": "-149.8226408"
-        }
+        "Permit": "R21-2439",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "MIDNIGHT SUN SOLAR LLC",
+        "Date": "8/30/21",
+        "year": "2021",
+        "Address": "6101 GROSS DRIVE, Anchorage, Alaska",
+        "Parcel": "1492232000",
+        "Units": "0",
+        "Legal": "CHUGACH ESTATES BLK 2 LT 16B G:2034",
+        "Valuation": "24527",
+        "formatted_address": "6101 Gross Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -11999,21 +10223,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2492",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/30/21",
-          "year": "2021",
-          "Address": "4700 VIRGO, Anchorage, Alaska",
-          "Parcel": "2009170000",
-          "Units": "0",
-          "Legal": "MINDYER MANORS BLK 2 LT 3 G:3336",
-          "Valuation": "12452",
-          "formatted_address": "4700 Virgo Ave, Anchorage, AK 99516, USA",
-          "lat": "61.06940160000001",
-          "lng": "-149.7943212"
-        }
+        "Permit": "R21-2492",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/30/21",
+        "year": "2021",
+        "Address": "4700 VIRGO, Anchorage, Alaska",
+        "Parcel": "2009170000",
+        "Units": "0",
+        "Legal": "MINDYER MANORS BLK 2 LT 3 G:3336",
+        "Valuation": "12452",
+        "formatted_address": "4700 Virgo Ave, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -12026,21 +10246,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2500",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/30/21",
-          "year": "2021",
-          "Address": "6700 MULBERRY DRIVE, Anchorage, Alaska",
-          "Parcel": "1206214000",
-          "Units": "0",
-          "Legal": "WOODLAND LAKES DEV UNIT #1 BLK 3 LT 37 G:2026",
-          "Valuation": "22000",
-          "formatted_address": "6700 Mulberry Dr, Anchorage, AK 99502, USA",
-          "lat": "61.1605664",
-          "lng": "-149.9415463"
-        }
+        "Permit": "R21-2500",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/30/21",
+        "year": "2021",
+        "Address": "6700 MULBERRY DRIVE, Anchorage, Alaska",
+        "Parcel": "1206214000",
+        "Units": "0",
+        "Legal": "WOODLAND LAKES DEV UNIT #1 BLK 3 LT 37 G:2026",
+        "Valuation": "22000",
+        "formatted_address": "6700 Mulberry Dr, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -12053,21 +10269,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2532",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/30/21",
-          "year": "2021",
-          "Address": "915 CLAY COURT, Anchorage, Alaska",
-          "Parcel": "116331000",
-          "Units": "0",
-          "Legal": "KAPINGEN LT 18A G:1529",
-          "Valuation": "19386",
-          "formatted_address": "915 Clay Ct, Anchorage, AK 99503, USA",
-          "lat": "61.2014058",
-          "lng": "-149.8996572"
-        }
+        "Permit": "R21-2532",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/30/21",
+        "year": "2021",
+        "Address": "915 CLAY COURT, Anchorage, Alaska",
+        "Parcel": "116331000",
+        "Units": "0",
+        "Legal": "KAPINGEN LT 18A G:1529",
+        "Valuation": "19386",
+        "formatted_address": "915 Clay Ct, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -12080,21 +10292,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2538",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/30/21",
-          "year": "2021",
-          "Address": "E 728 75TH, Anchorage, Alaska",
-          "Parcel": "1304119000",
-          "Units": "0",
-          "Legal": "HOLLOWBROOK BLK 1 LT 3 G:2131",
-          "Valuation": "38000",
-          "formatted_address": "728 E St, Anchorage, AK 99501, USA",
-          "lat": "61.21501209999999",
-          "lng": "-149.8917542"
-        }
+        "Permit": "R21-2538",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/30/21",
+        "year": "2021",
+        "Address": "E 728 75TH, Anchorage, Alaska",
+        "Parcel": "1304119000",
+        "Units": "0",
+        "Legal": "HOLLOWBROOK BLK 1 LT 3 G:2131",
+        "Valuation": "38000",
+        "formatted_address": "728 E St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -12107,21 +10315,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2768",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "9/30/21",
-          "year": "2021",
-          "Address": "10487 ELMORE, Anchorage, Alaska",
-          "Parcel": "1511255000",
-          "Units": "0",
-          "Legal": "MILLPLACE ESTATES LT   2  G:2536",
-          "Valuation": "32000",
-          "formatted_address": "10487 Elmore Rd, Anchorage, AK 99507, USA",
-          "lat": "61.12568599999999",
-          "lng": "-149.803203"
-        }
+        "Permit": "R21-2768",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "9/30/21",
+        "year": "2021",
+        "Address": "10487 ELMORE, Anchorage, Alaska",
+        "Parcel": "1511255000",
+        "Units": "0",
+        "Legal": "MILLPLACE ESTATES LT   2  G:2536",
+        "Valuation": "32000",
+        "formatted_address": "10487 Elmore Rd, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -12134,21 +10338,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2777",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/21",
-          "year": "2021",
-          "Address": "4800 SNOW CIRCLE, Anchorage, Alaska",
-          "Parcel": "631118000",
-          "Units": "0",
-          "Legal": "PINE VALLEY ESTATES BLK   1 LT   8  G:1537",
-          "Valuation": "19192",
-          "formatted_address": "4800 Snow Cir, Anchorage, AK 99508, USA",
-          "lat": "61.20122929999999",
-          "lng": "-149.7913247"
-        }
+        "Permit": "R21-2777",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/21",
+        "year": "2021",
+        "Address": "4800 SNOW CIRCLE, Anchorage, Alaska",
+        "Parcel": "631118000",
+        "Units": "0",
+        "Legal": "PINE VALLEY ESTATES BLK   1 LT   8  G:1537",
+        "Valuation": "19192",
+        "formatted_address": "4800 Snow Cir, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -12161,21 +10361,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2778",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/21",
-          "year": "2021",
-          "Address": "6060 BRISTOL, Anchorage, Alaska",
-          "Parcel": "1739133000",
-          "Units": "0",
-          "Legal": "MOUNTAIN PARK ESTATES BLK   8 LT   9  G:2838",
-          "Valuation": "18159",
-          "formatted_address": "6060 Bristol Dr, Anchorage, AK 99516, USA",
-          "lat": "61.10350690000001",
-          "lng": "-149.769608"
-        }
+        "Permit": "R21-2778",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/21",
+        "year": "2021",
+        "Address": "6060 BRISTOL, Anchorage, Alaska",
+        "Parcel": "1739133000",
+        "Units": "0",
+        "Legal": "MOUNTAIN PARK ESTATES BLK   8 LT   9  G:2838",
+        "Valuation": "18159",
+        "formatted_address": "6060 Bristol Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -12188,21 +10384,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2779",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/21",
-          "year": "2021",
-          "Address": "W 3301 70TH, Anchorage, Alaska",
-          "Parcel": "1214539000",
-          "Units": "0",
-          "Legal": "WINDSOR VILLAGE #1 BLK   4 LT  12  G:2126",
-          "Valuation": "11500",
-          "formatted_address": "3301 W 70th Pl, Anchorage, AK 99502, USA",
-          "lat": "61.15698459999999",
-          "lng": "-149.9406403"
-        }
+        "Permit": "R21-2779",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/21",
+        "year": "2021",
+        "Address": "W 3301 70TH, Anchorage, Alaska",
+        "Parcel": "1214539000",
+        "Units": "0",
+        "Legal": "WINDSOR VILLAGE #1 BLK   4 LT  12  G:2126",
+        "Valuation": "11500",
+        "formatted_address": "3301 W 70th Pl, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -12215,21 +10407,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2781",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "9/30/21",
-          "year": "2021",
-          "Address": "E 1819 24TH, Anchorage, Alaska",
-          "Parcel": "317214000",
-          "Units": "0",
-          "Legal": "ROGERS PARK TERRACE BLK   2 LT   5  G:1533",
-          "Valuation": "29000",
-          "formatted_address": "1819 E 24th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.19947219999999",
-          "lng": "-149.8474412"
-        }
+        "Permit": "R21-2781",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "9/30/21",
+        "year": "2021",
+        "Address": "E 1819 24TH, Anchorage, Alaska",
+        "Parcel": "317214000",
+        "Units": "0",
+        "Legal": "ROGERS PARK TERRACE BLK   2 LT   5  G:1533",
+        "Valuation": "29000",
+        "formatted_address": "1819 E 24th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -12242,21 +10430,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2842",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "9/30/21",
-          "year": "2021",
-          "Address": "3202 SEAPORT, Anchorage, Alaska",
-          "Parcel": "1917152000",
-          "Units": "0",
-          "Legal": "DISCOVERY HEIGHTS PHASE 3 BLK   4 LT  17  G:2626",
-          "Valuation": "21000",
-          "formatted_address": "3202 Seaport Cir, Anchorage, AK 99515, USA",
-          "lat": "61.1171975",
-          "lng": "-149.9410569"
-        }
+        "Permit": "R21-2842",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "9/30/21",
+        "year": "2021",
+        "Address": "3202 SEAPORT, Anchorage, Alaska",
+        "Parcel": "1917152000",
+        "Units": "0",
+        "Legal": "DISCOVERY HEIGHTS PHASE 3 BLK   4 LT  17  G:2626",
+        "Valuation": "21000",
+        "formatted_address": "3202 Seaport Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -12269,21 +10453,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2858",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/21",
-          "year": "2021",
-          "Address": "219 BUNN, Anchorage, Alaska",
-          "Parcel": "503145000",
-          "Units": "0",
-          "Legal": "FAIRVIEW EXTENSION BLK  31 LT   3A  G:1236",
-          "Valuation": "14512",
-          "formatted_address": "219 N Bunn St, Anchorage, AK 99508, USA",
-          "lat": "61.22530090000001",
-          "lng": "-149.7985659"
-        }
+        "Permit": "R21-2858",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/21",
+        "year": "2021",
+        "Address": "219 BUNN, Anchorage, Alaska",
+        "Parcel": "503145000",
+        "Units": "0",
+        "Legal": "FAIRVIEW EXTENSION BLK  31 LT   3A  G:1236",
+        "Valuation": "14512",
+        "formatted_address": "219 N Bunn St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -12296,21 +10476,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2859",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/21",
-          "year": "2021",
-          "Address": "1816 WESTVIEW, Anchorage, Alaska",
-          "Parcel": "620262000",
-          "Units": "0",
-          "Legal": "THE FOOTHILLS BLK   7 LT  33  G:1441",
-          "Valuation": "29000",
-          "formatted_address": "1816 Westview Cir, Anchorage, AK 99504, USA",
-          "lat": "61.204547",
-          "lng": "-149.7259247"
-        }
+        "Permit": "R21-2859",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/21",
+        "year": "2021",
+        "Address": "1816 WESTVIEW, Anchorage, Alaska",
+        "Parcel": "620262000",
+        "Units": "0",
+        "Legal": "THE FOOTHILLS BLK   7 LT  33  G:1441",
+        "Valuation": "29000",
+        "formatted_address": "1816 Westview Cir, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -12323,21 +10499,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2863",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/21",
-          "year": "2021",
-          "Address": "2060 SARATOGA, Anchorage, Alaska",
-          "Parcel": "124320000",
-          "Units": "0",
-          "Legal": "HUNTINGTON PARK #1 BLK   2 LT  17  G:1528",
-          "Valuation": "21242",
-          "formatted_address": "2060 Saratoga Ave, Anchorage, AK 99517, USA",
-          "lat": "61.1963841",
-          "lng": "-149.92386"
-        }
+        "Permit": "R21-2863",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/21",
+        "year": "2021",
+        "Address": "2060 SARATOGA, Anchorage, Alaska",
+        "Parcel": "124320000",
+        "Units": "0",
+        "Legal": "HUNTINGTON PARK #1 BLK   2 LT  17  G:1528",
+        "Valuation": "21242",
+        "formatted_address": "2060 Saratoga Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -12350,21 +10522,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-2936",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "10/31/21",
-          "year": "2021",
-          "Address": "3355 DICKSON, Anchorage, Alaska",
-          "Parcel": "705527000",
-          "Units": "0",
-          "Legal": "CLYDE M DICKSON BLK   1 LT  12  G:1640",
-          "Valuation": "32000",
-          "formatted_address": "3355 Dickson Rd, Anchorage, AK 99504, USA",
-          "lat": "61.1900971",
-          "lng": "-149.7368678"
-        }
+        "Permit": "R21-2936",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "10/31/21",
+        "year": "2021",
+        "Address": "3355 DICKSON, Anchorage, Alaska",
+        "Parcel": "705527000",
+        "Units": "0",
+        "Legal": "CLYDE M DICKSON BLK   1 LT  12  G:1640",
+        "Valuation": "32000",
+        "formatted_address": "3355 Dickson Rd, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -12377,21 +10545,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-3025",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "10/31/21",
-          "year": "2021",
-          "Address": "E 3613 17TH, Anchorage, Alaska",
-          "Parcel": "413506000",
-          "Units": "0",
-          "Legal": "THUNDERBIRD TERRACE BLK  11 LT  15  G:1435",
-          "Valuation": "15200",
-          "formatted_address": "3613 E 17th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.20554130000001",
-          "lng": "-149.8136213"
-        }
+        "Permit": "R21-3025",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "10/31/21",
+        "year": "2021",
+        "Address": "E 3613 17TH, Anchorage, Alaska",
+        "Parcel": "413506000",
+        "Units": "0",
+        "Legal": "THUNDERBIRD TERRACE BLK  11 LT  15  G:1435",
+        "Valuation": "15200",
+        "formatted_address": "3613 E 17th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -12404,21 +10568,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-3092",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "11/30/21",
-          "year": "2021",
-          "Address": "1119 G, Anchorage, Alaska",
-          "Parcel": "214448000",
-          "Units": "0",
-          "Legal": "SOUTH ADDITION BLK  22A LT  10  G:1330",
-          "Valuation": "14928",
-          "formatted_address": "1119 G St, Anchorage, AK 99501, USA",
-          "lat": "61.2112322",
-          "lng": "-149.8949889"
-        }
+        "Permit": "R21-3092",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "11/30/21",
+        "year": "2021",
+        "Address": "1119 G, Anchorage, Alaska",
+        "Parcel": "214448000",
+        "Units": "0",
+        "Legal": "SOUTH ADDITION BLK  22A LT  10  G:1330",
+        "Valuation": "14928",
+        "formatted_address": "1119 G St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -12431,21 +10591,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-3136",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "12/31/21",
-          "year": "2021",
-          "Address": "W 3231 80TH, Anchorage, Alaska",
-          "Parcel": "1224141000",
-          "Units": "0",
-          "Legal": "SHADY BIRCH #1 LT  11  G:2226",
-          "Valuation": "12177",
-          "formatted_address": "3231 W 80th Ave, Anchorage, AK 99502, USA",
-          "lat": "61.14853099999999",
-          "lng": "-149.9401105"
-        }
+        "Permit": "R21-3136",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "12/31/21",
+        "year": "2021",
+        "Address": "W 3231 80TH, Anchorage, Alaska",
+        "Parcel": "1224141000",
+        "Units": "0",
+        "Legal": "SHADY BIRCH #1 LT  11  G:2226",
+        "Valuation": "12177",
+        "formatted_address": "3231 W 80th Ave, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -12458,21 +10614,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R21-3137",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "12/31/21",
-          "year": "2021",
-          "Address": "9010 SAHALEE, Anchorage, Alaska",
-          "Parcel": "1504411000",
-          "Units": "0",
-          "Legal": "SAHALEE BLK   1 LT  22  G:2336",
-          "Valuation": "21193",
-          "formatted_address": "9010 Sahalee Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1392714",
-          "lng": "-149.7933005"
-        }
+        "Permit": "R21-3137",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "12/31/21",
+        "year": "2021",
+        "Address": "9010 SAHALEE, Anchorage, Alaska",
+        "Parcel": "1504411000",
+        "Units": "0",
+        "Legal": "SAHALEE BLK   1 LT  22  G:2336",
+        "Valuation": "21193",
+        "formatted_address": "9010 Sahalee Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -12485,21 +10637,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1017",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "MIDNIGHT SUN SOLAR LLC",
-          "Date": "1/31/22",
-          "year": "2022",
-          "Address": "1621 WICKERSHAM, Anchorage, Alaska",
-          "Parcel": "919239000",
-          "Units": "0",
-          "Legal": "WICKERSHAM PARK #1 BLK   8 LT  26  G:1833",
-          "Valuation": "18972",
-          "formatted_address": "1621 Wickersham Dr, Anchorage, AK 99507, USA",
-          "lat": "61.17591840000001",
-          "lng": "-149.8512565"
-        }
+        "Permit": "R22-1017",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "MIDNIGHT SUN SOLAR LLC",
+        "Date": "1/31/22",
+        "year": "2022",
+        "Address": "1621 WICKERSHAM, Anchorage, Alaska",
+        "Parcel": "919239000",
+        "Units": "0",
+        "Legal": "WICKERSHAM PARK #1 BLK   8 LT  26  G:1833",
+        "Valuation": "18972",
+        "formatted_address": "1621 Wickersham Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -12512,21 +10660,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C22-1273",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/22",
-          "year": "2022",
-          "Address": "W 1049 NORTHERN LIGHTS, Anchorage, Alaska",
-          "Parcel": "125179000",
-          "Units": "0",
-          "Legal": "SUNBEAM BLK   3 LT  12  G:1529",
-          "Valuation": "48245",
-          "formatted_address": "1049 E Northern Lights Blvd, Anchorage, AK 99508, USA",
-          "lat": "61.1952119",
-          "lng": "-149.8633072"
-        }
+        "Permit": "C22-1273",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/22",
+        "year": "2022",
+        "Address": "W 1049 NORTHERN LIGHTS, Anchorage, Alaska",
+        "Parcel": "125179000",
+        "Units": "0",
+        "Legal": "SUNBEAM BLK   3 LT  12  G:1529",
+        "Valuation": "48245",
+        "formatted_address": "1049 E Northern Lights Blvd, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -12539,21 +10683,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1188",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/22",
-          "year": "2022",
-          "Address": "10475 BLACKWOLF, Anchorage, Alaska",
-          "Parcel": "4103330000",
-          "Units": "0",
-          "Legal": "END OF THE ROAD LT  2A  G:2143",
-          "Valuation": "29712",
-          "formatted_address": "10475 Blackwolf Cir, Anchorage, AK 99507, USA",
-          "lat": "61.15413299999999",
-          "lng": "-149.6885299"
-        }
+        "Permit": "R22-1188",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/22",
+        "year": "2022",
+        "Address": "10475 BLACKWOLF, Anchorage, Alaska",
+        "Parcel": "4103330000",
+        "Units": "0",
+        "Legal": "END OF THE ROAD LT  2A  G:2143",
+        "Valuation": "29712",
+        "formatted_address": "10475 Blackwolf Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -12566,21 +10706,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1193",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/22",
-          "year": "2022",
-          "Address": "6816 DOUBLE TREE, Anchorage, Alaska",
-          "Parcel": "1531118000",
-          "Units": "0",
-          "Legal": "VALLI VUE ESTATES #1 BLK   1 LT  17  G:2539",
-          "Valuation": "9393",
-          "formatted_address": "6816 Double Tree Ct, Anchorage, AK 99507, USA",
-          "lat": "61.123865",
-          "lng": "-149.7544876"
-        }
+        "Permit": "R22-1193",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/22",
+        "year": "2022",
+        "Address": "6816 DOUBLE TREE, Anchorage, Alaska",
+        "Parcel": "1531118000",
+        "Units": "0",
+        "Legal": "VALLI VUE ESTATES #1 BLK   1 LT  17  G:2539",
+        "Valuation": "9393",
+        "formatted_address": "6816 Double Tree Ct, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -12593,21 +10729,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1194",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/22",
-          "year": "2022",
-          "Address": "1207 G, Anchorage, Alaska",
-          "Parcel": "214453000",
-          "Units": "0",
-          "Legal": "12TH AVENUE LT   1  G:1330",
-          "Valuation": "12338",
-          "formatted_address": "1207 G St, Anchorage, AK 99501, USA",
-          "lat": "61.2105083",
-          "lng": "-149.89522"
-        }
+        "Permit": "R22-1194",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/22",
+        "year": "2022",
+        "Address": "1207 G, Anchorage, Alaska",
+        "Parcel": "214453000",
+        "Units": "0",
+        "Legal": "12TH AVENUE LT   1  G:1330",
+        "Valuation": "12338",
+        "formatted_address": "1207 G St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -12620,21 +10752,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1196",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/22",
-          "year": "2022",
-          "Address": "2822 ALDER, Anchorage, Alaska",
-          "Parcel": "415422000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   7 LT  47  G:1534",
-          "Valuation": "10000",
-          "formatted_address": "2822 Alder Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1997873",
-          "lng": "-149.8275495"
-        }
+        "Permit": "R22-1196",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/22",
+        "year": "2022",
+        "Address": "2822 ALDER, Anchorage, Alaska",
+        "Parcel": "415422000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   7 LT  47  G:1534",
+        "Valuation": "10000",
+        "formatted_address": "2822 Alder Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -12647,21 +10775,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1197",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/22",
-          "year": "2022",
-          "Address": "1601 BETULA, Anchorage, Alaska",
-          "Parcel": "1628638000",
-          "Units": "0",
-          "Legal": "CEDAR HOLLOW BLK   2 LT  34  G:2532",
-          "Valuation": "18495",
-          "formatted_address": "1601 Betula Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1286594",
-          "lng": "-149.8532039"
-        }
+        "Permit": "R22-1197",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/22",
+        "year": "2022",
+        "Address": "1601 BETULA, Anchorage, Alaska",
+        "Parcel": "1628638000",
+        "Units": "0",
+        "Legal": "CEDAR HOLLOW BLK   2 LT  34  G:2532",
+        "Valuation": "18495",
+        "formatted_address": "1601 Betula Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -12674,21 +10798,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1198",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/22",
-          "year": "2022",
-          "Address": "1820 WESTVIEW, Anchorage, Alaska",
-          "Parcel": "620263000",
-          "Units": "0",
-          "Legal": "THE FOOTHILLS BLK   7 LT  34  G:1441",
-          "Valuation": "9608",
-          "formatted_address": "1820 Westview Cir, Anchorage, AK 99504, USA",
-          "lat": "61.20428210000001",
-          "lng": "-149.7256681"
-        }
+        "Permit": "R22-1198",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/22",
+        "year": "2022",
+        "Address": "1820 WESTVIEW, Anchorage, Alaska",
+        "Parcel": "620263000",
+        "Units": "0",
+        "Legal": "THE FOOTHILLS BLK   7 LT  34  G:1441",
+        "Valuation": "9608",
+        "formatted_address": "1820 Westview Cir, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -12701,21 +10821,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1200",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/22",
-          "year": "2022",
-          "Address": "10960 VOSIKOF, Anchorage, Alaska",
-          "Parcel": "1516412000",
-          "Units": "0",
-          "Legal": "TIMBERLINE LT  11  G:2641",
-          "Valuation": "31857",
-          "formatted_address": "10960 Vosikof Pl, Anchorage, AK 99507, USA",
-          "lat": "61.1214925",
-          "lng": "-149.726281"
-        }
+        "Permit": "R22-1200",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/22",
+        "year": "2022",
+        "Address": "10960 VOSIKOF, Anchorage, Alaska",
+        "Parcel": "1516412000",
+        "Units": "0",
+        "Legal": "TIMBERLINE LT  11  G:2641",
+        "Valuation": "31857",
+        "formatted_address": "10960 Vosikof Pl, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -12728,21 +10844,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1201",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/22",
-          "year": "2022",
-          "Address": "11302 TOTEM, Anchorage, Alaska",
-          "Parcel": "1514308000",
-          "Units": "0",
-          "Legal": "DAVID RING LT   2A  G:2637",
-          "Valuation": "7983",
-          "formatted_address": "11302 Totem Rd, Anchorage, AK 99516, USA",
-          "lat": "61.1183825",
-          "lng": "-149.7829488"
-        }
+        "Permit": "R22-1201",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/22",
+        "year": "2022",
+        "Address": "11302 TOTEM, Anchorage, Alaska",
+        "Parcel": "1514308000",
+        "Units": "0",
+        "Legal": "DAVID RING LT   2A  G:2637",
+        "Valuation": "7983",
+        "formatted_address": "11302 Totem Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -12755,21 +10867,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1202",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/22",
-          "year": "2022",
-          "Address": "8150 GRAYHAWK, Anchorage, Alaska",
-          "Parcel": "1423538000",
-          "Units": "0",
-          "Legal": "GRAY HAWK LT  16  G:2235",
-          "Valuation": "10445",
-          "formatted_address": "8150 Grayhawk Cir, Anchorage, AK 99507, USA",
-          "lat": "61.14682730000001",
-          "lng": "-149.8170555"
-        }
+        "Permit": "R22-1202",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/22",
+        "year": "2022",
+        "Address": "8150 GRAYHAWK, Anchorage, Alaska",
+        "Parcel": "1423538000",
+        "Units": "0",
+        "Legal": "GRAY HAWK LT  16  G:2235",
+        "Valuation": "10445",
+        "formatted_address": "8150 Grayhawk Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -12782,21 +10890,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1203",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/22",
-          "year": "2022",
-          "Address": "8291 OPAL, Anchorage, Alaska",
-          "Parcel": "1226434000",
-          "Units": "0",
-          "Legal": "DIMOND BIRCH #2 BLK   2 LT   3  G:2227",
-          "Valuation": "16870",
-          "formatted_address": "8291 Opal Dr, Anchorage, AK 99502, USA",
-          "lat": "61.14603649999999",
-          "lng": "-149.9307603"
-        }
+        "Permit": "R22-1203",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/22",
+        "year": "2022",
+        "Address": "8291 OPAL, Anchorage, Alaska",
+        "Parcel": "1226434000",
+        "Units": "0",
+        "Legal": "DIMOND BIRCH #2 BLK   2 LT   3  G:2227",
+        "Valuation": "16870",
+        "formatted_address": "8291 Opal Dr, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -12809,21 +10913,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1204",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/22",
-          "year": "2022",
-          "Address": "1552 PRIMROSE STREET, Anchorage, Alaska",
-          "Parcel": "412150000",
-          "Units": "0",
-          "Legal": "GRANDVIEW GARDENS BLK  14 LT  15  G:1435",
-          "Valuation": "10030",
-          "formatted_address": "1552 Primrose St, Anchorage, AK 99508, USA",
-          "lat": "61.20691230000001",
-          "lng": "-149.8105589"
-        }
+        "Permit": "R22-1204",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/22",
+        "year": "2022",
+        "Address": "1552 PRIMROSE STREET, Anchorage, Alaska",
+        "Parcel": "412150000",
+        "Units": "0",
+        "Legal": "GRANDVIEW GARDENS BLK  14 LT  15  G:1435",
+        "Valuation": "10030",
+        "formatted_address": "1552 Primrose St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -12836,21 +10936,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1205",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/22",
-          "year": "2022",
-          "Address": "1541 I STREET, Anchorage, Alaska",
-          "Parcel": "109154000",
-          "Units": "0",
-          "Legal": "WELCH'S BLK 42A LT  8A  G:1429",
-          "Valuation": "24173",
-          "formatted_address": "1541 I St, Anchorage, AK 99501, USA",
-          "lat": "61.2070075",
-          "lng": "-149.8989277"
-        }
+        "Permit": "R22-1205",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/22",
+        "year": "2022",
+        "Address": "1541 I STREET, Anchorage, Alaska",
+        "Parcel": "109154000",
+        "Units": "0",
+        "Legal": "WELCH'S BLK 42A LT  8A  G:1429",
+        "Valuation": "24173",
+        "formatted_address": "1541 I St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -12863,21 +10959,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1313",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/22",
-          "year": "2022",
-          "Address": "5063 HERITAGE HEIGHTS, Anchorage, Alaska",
-          "Parcel": "1522146000",
-          "Units": "0",
-          "Legal": "CROSS VIEW ESTATES BLK   1 LT   3  G:2737",
-          "Valuation": "46938",
-          "formatted_address": "5063 Heritage Heights Dr, Anchorage, AK 99516, USA",
-          "lat": "61.1106972",
-          "lng": "-149.7885648"
-        }
+        "Permit": "R22-1313",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/22",
+        "year": "2022",
+        "Address": "5063 HERITAGE HEIGHTS, Anchorage, Alaska",
+        "Parcel": "1522146000",
+        "Units": "0",
+        "Legal": "CROSS VIEW ESTATES BLK   1 LT   3  G:2737",
+        "Valuation": "46938",
+        "formatted_address": "5063 Heritage Heights Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -12890,21 +10982,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1404",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/22",
-          "year": "2022",
-          "Address": "3540 WINGATE, Anchorage, Alaska",
-          "Parcel": "323166000",
-          "Units": "0",
-          "Legal": "COLLEGE VILLAGE #13 BLK  31 LT  11  G:1632",
-          "Valuation": "16448",
-          "formatted_address": "111 W Ship Creek Ave, Anchorage, AK 99501, USA",
-          "lat": "61.222874",
-          "lng": "-149.88371"
-        }
+        "Permit": "R22-1404",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/22",
+        "year": "2022",
+        "Address": "3540 WINGATE, Anchorage, Alaska",
+        "Parcel": "323166000",
+        "Units": "0",
+        "Legal": "COLLEGE VILLAGE #13 BLK  31 LT  11  G:1632",
+        "Valuation": "16448",
+        "formatted_address": "111 W Ship Creek Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -12917,21 +11005,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1405",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/22",
-          "year": "2022",
-          "Address": "5100 REBANO, Anchorage, Alaska",
-          "Parcel": "1738128000",
-          "Units": "0",
-          "Legal": "CONTOUR ACRES #4 TR   A-1  G:2837",
-          "Valuation": "76628",
-          "formatted_address": "5100 Rebano Dr, Anchorage, AK 99516, USA",
-          "lat": "61.1021083",
-          "lng": "-149.7858059"
-        }
+        "Permit": "R22-1405",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/22",
+        "year": "2022",
+        "Address": "5100 REBANO, Anchorage, Alaska",
+        "Parcel": "1738128000",
+        "Units": "0",
+        "Legal": "CONTOUR ACRES #4 TR   A-1  G:2837",
+        "Valuation": "76628",
+        "formatted_address": "5100 Rebano Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -12944,21 +11028,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1406",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/22",
-          "year": "2022",
-          "Address": "3657 EASTWIND, Anchorage, Alaska",
-          "Parcel": "1841158000",
-          "Units": "0",
-          "Legal": "TURNAGAIN VIEW ESTATES PH 4 BLK   6 LT  14  G:2935",
-          "Valuation": "18868",
-          "formatted_address": "3657 Eastwind Dr, Anchorage, AK 99516, USA",
-          "lat": "61.0988455",
-          "lng": "-149.8151036"
-        }
+        "Permit": "R22-1406",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/22",
+        "year": "2022",
+        "Address": "3657 EASTWIND, Anchorage, Alaska",
+        "Parcel": "1841158000",
+        "Units": "0",
+        "Legal": "TURNAGAIN VIEW ESTATES PH 4 BLK   6 LT  14  G:2935",
+        "Valuation": "18868",
+        "formatted_address": "3657 Eastwind Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -12971,21 +11051,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1408",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/22",
-          "year": "2022",
-          "Address": "13115 GULF CIRCLE, Anchorage, Alaska",
-          "Parcel": "1806131000",
-          "Units": "0",
-          "Legal": "OCEANVIEW #1 BLK   8 LT  18  G:2831",
-          "Valuation": "28000",
-          "formatted_address": "13115 Gulf Cir, Anchorage, AK 99515, USA",
-          "lat": "61.1025326",
-          "lng": "-149.8686118"
-        }
+        "Permit": "R22-1408",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/22",
+        "year": "2022",
+        "Address": "13115 GULF CIRCLE, Anchorage, Alaska",
+        "Parcel": "1806131000",
+        "Units": "0",
+        "Legal": "OCEANVIEW #1 BLK   8 LT  18  G:2831",
+        "Valuation": "28000",
+        "formatted_address": "13115 Gulf Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -12998,21 +11074,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1434",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/22",
-          "year": "2022",
-          "Address": "W 5031 80TH, Anchorage, Alaska",
-          "Parcel": "1111130000",
-          "Units": "0",
-          "Legal": "SAND LAKE #1 LT   2A  G:2224",
-          "Valuation": "2400",
-          "formatted_address": "5031 W 80th Ave, Anchorage, AK 99502, USA",
-          "lat": "61.1488683",
-          "lng": "-149.973538"
-        }
+        "Permit": "R22-1434",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/22",
+        "year": "2022",
+        "Address": "W 5031 80TH, Anchorage, Alaska",
+        "Parcel": "1111130000",
+        "Units": "0",
+        "Legal": "SAND LAKE #1 LT   2A  G:2224",
+        "Valuation": "2400",
+        "formatted_address": "5031 W 80th Ave, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -13025,21 +11097,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1544",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "3967 EASTER ISLAND, Anchorage, Alaska",
-          "Parcel": "1141281000",
-          "Units": "0",
-          "Legal": "RESOLUTION POINTE PH 3 BLK  1A LT  13  G:2525",
-          "Valuation": "26000",
-          "formatted_address": "3967 Easter Island Cir, Anchorage, AK 99515, USA",
-          "lat": "61.1269927",
-          "lng": "-149.9523546"
-        }
+        "Permit": "R22-1544",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "3967 EASTER ISLAND, Anchorage, Alaska",
+        "Parcel": "1141281000",
+        "Units": "0",
+        "Legal": "RESOLUTION POINTE PH 3 BLK  1A LT  13  G:2525",
+        "Valuation": "26000",
+        "formatted_address": "3967 Easter Island Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -13052,21 +11120,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1548",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "E 1726 58TH, Anchorage, Alaska",
-          "Parcel": "927504000",
-          "Units": "0",
-          "Legal": "IGLOO ESTATES BLK   3 LT  13  G:1933",
-          "Valuation": "26000",
-          "formatted_address": "1726 E 58th Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1681146",
-          "lng": "-149.849566"
-        }
+        "Permit": "R22-1548",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "E 1726 58TH, Anchorage, Alaska",
+        "Parcel": "927504000",
+        "Units": "0",
+        "Legal": "IGLOO ESTATES BLK   3 LT  13  G:1933",
+        "Valuation": "26000",
+        "formatted_address": "1726 E 58th Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -13079,21 +11143,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1549",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "12914 ALGARIN CIRCLE, Anchorage, Alaska",
-          "Parcel": "1702388000",
-          "Units": "0",
-          "Legal": "GREENBROOK BLK   2 LT  21C  G:2839",
-          "Valuation": "16000",
-          "formatted_address": "12914 Algarin Cir, Anchorage, AK 99516, USA",
-          "lat": "61.10400120000001",
-          "lng": "-149.7581145"
-        }
+        "Permit": "R22-1549",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "12914 ALGARIN CIRCLE, Anchorage, Alaska",
+        "Parcel": "1702388000",
+        "Units": "0",
+        "Legal": "GREENBROOK BLK   2 LT  21C  G:2839",
+        "Valuation": "16000",
+        "formatted_address": "12914 Algarin Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -13106,21 +11166,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1573",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "5270 HERITAGE HEIGHTS, Anchorage, Alaska",
-          "Parcel": "1530168000",
-          "Units": "0",
-          "Legal": "CROSS VIEW ESTATES BLK   2 LT  22  G:2737",
-          "Valuation": "32000",
-          "formatted_address": "5270 Heritage Heights Dr, Anchorage, AK 99516, USA",
-          "lat": "61.11268229999999",
-          "lng": "-149.7860905"
-        }
+        "Permit": "R22-1573",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "5270 HERITAGE HEIGHTS, Anchorage, Alaska",
+        "Parcel": "1530168000",
+        "Units": "0",
+        "Legal": "CROSS VIEW ESTATES BLK   2 LT  22  G:2737",
+        "Valuation": "32000",
+        "formatted_address": "5270 Heritage Heights Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -13133,21 +11189,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1574",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "2164 ALDER, Anchorage, Alaska",
-          "Parcel": "415413000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   7 LT  38 P-254 G:1534",
-          "Valuation": "13520",
-          "formatted_address": "2164 Alder Dr, Anchorage, AK 99508, USA",
-          "lat": "61.20075369999999",
-          "lng": "-149.8289968"
-        }
+        "Permit": "R22-1574",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "2164 ALDER, Anchorage, Alaska",
+        "Parcel": "415413000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   7 LT  38 P-254 G:1534",
+        "Valuation": "13520",
+        "formatted_address": "2164 Alder Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -13160,21 +11212,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1575",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "12550 TANADA, Anchorage, Alaska",
-          "Parcel": "1802532000",
-          "Units": "0",
-          "Legal": "TANAGA TERRACE BLK   2 LT   4  G:2832",
-          "Valuation": "21460",
-          "formatted_address": "12550 Tanada Loop, Anchorage, AK 99515, USA",
-          "lat": "61.1069223",
-          "lng": "-149.8514769"
-        }
+        "Permit": "R22-1575",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "12550 TANADA, Anchorage, Alaska",
+        "Parcel": "1802532000",
+        "Units": "0",
+        "Legal": "TANAGA TERRACE BLK   2 LT   4  G:2832",
+        "Valuation": "21460",
+        "formatted_address": "12550 Tanada Loop, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -13187,21 +11235,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1576",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "5800 BULGARIA, Anchorage, Alaska",
-          "Parcel": "2041428000",
-          "Units": "0",
-          "Legal": "PARADISE VALLEY BLK  10 LT   1  G:3538",
-          "Valuation": "15520",
-          "formatted_address": "5800 Bulgaria Dr, Anchorage, AK 99516, USA",
-          "lat": "61.05557429999999",
-          "lng": "-149.7739902"
-        }
+        "Permit": "R22-1576",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "5800 BULGARIA, Anchorage, Alaska",
+        "Parcel": "2041428000",
+        "Units": "0",
+        "Legal": "PARADISE VALLEY BLK  10 LT   1  G:3538",
+        "Valuation": "15520",
+        "formatted_address": "5800 Bulgaria Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -13214,21 +11258,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1577",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "8739 EMERALD STREET, Anchorage, Alaska",
-          "Parcel": "1115224000",
-          "Units": "0",
-          "Legal": "JEWEL LAKE HEIGHTS #1 LT  36B  G:2325",
-          "Valuation": "34082",
-          "formatted_address": "8739 Emerald Dr, Anchorage, AK 99502, USA",
-          "lat": "61.1414505",
-          "lng": "-149.9660395"
-        }
+        "Permit": "R22-1577",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "8739 EMERALD STREET, Anchorage, Alaska",
+        "Parcel": "1115224000",
+        "Units": "0",
+        "Legal": "JEWEL LAKE HEIGHTS #1 LT  36B  G:2325",
+        "Valuation": "34082",
+        "formatted_address": "8739 Emerald Dr, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -13241,21 +11281,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1578",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "6951 VIBURNUM DRIVE, Anchorage, Alaska",
-          "Parcel": "1411426000",
-          "Units": "0",
-          "Legal": "JOHNSON-YOUNG #1 BLK   2 LT  16  G:2132",
-          "Valuation": "13720",
-          "formatted_address": "6951 Viburnum Dr, Anchorage, AK 99507, USA",
-          "lat": "61.15739310000001",
-          "lng": "-149.8496099"
-        }
+        "Permit": "R22-1578",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "6951 VIBURNUM DRIVE, Anchorage, Alaska",
+        "Parcel": "1411426000",
+        "Units": "0",
+        "Legal": "JOHNSON-YOUNG #1 BLK   2 LT  16  G:2132",
+        "Valuation": "13720",
+        "formatted_address": "6951 Viburnum Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -13268,21 +11304,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1579",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "8230 STRATTON, Anchorage, Alaska",
-          "Parcel": "1422342000",
-          "Units": "0",
-          "Legal": "SIDE BY SIDE LT   9A  G:2234",
-          "Valuation": "22466",
-          "formatted_address": "8230 Stratton Cir, Anchorage, AK 99507, USA",
-          "lat": "61.146239",
-          "lng": "-149.8226989"
-        }
+        "Permit": "R22-1579",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "8230 STRATTON, Anchorage, Alaska",
+        "Parcel": "1422342000",
+        "Units": "0",
+        "Legal": "SIDE BY SIDE LT   9A  G:2234",
+        "Valuation": "22466",
+        "formatted_address": "8230 Stratton Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -13295,21 +11327,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1580",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "4040 JUSTIN, Anchorage, Alaska",
-          "Parcel": "1431193000",
-          "Units": "0",
-          "Legal": "JENNIFER PARK LT   5  G:2335",
-          "Valuation": "10940",
-          "formatted_address": "4040 Justin Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1395464",
-          "lng": "-149.8065564"
-        }
+        "Permit": "R22-1580",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "4040 JUSTIN, Anchorage, Alaska",
+        "Parcel": "1431193000",
+        "Units": "0",
+        "Legal": "JENNIFER PARK LT   5  G:2335",
+        "Valuation": "10940",
+        "formatted_address": "4040 Justin Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -13322,21 +11350,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1581",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "8820 SPENDLOVE, Anchorage, Alaska",
-          "Parcel": "1740153000",
-          "Units": "0",
-          "Legal": "SPENDLOVE VIEW HEIGHTS #3 BLK   5 LT   2  G:2841",
-          "Valuation": "19555",
-          "formatted_address": "8820 Spendlove Dr, Anchorage, AK 99516, USA",
-          "lat": "61.1028482",
-          "lng": "-149.7169125"
-        }
+        "Permit": "R22-1581",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "8820 SPENDLOVE, Anchorage, Alaska",
+        "Parcel": "1740153000",
+        "Units": "0",
+        "Legal": "SPENDLOVE VIEW HEIGHTS #3 BLK   5 LT   2  G:2841",
+        "Valuation": "19555",
+        "formatted_address": "8820 Spendlove Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -13349,21 +11373,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1617",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "9620 ARLENE, Anchorage, Alaska",
-          "Parcel": "1241232000",
-          "Units": "0",
-          "Legal": "CAMPBELL LAKE HEIGHTS #10 BLK   2 LT  11  G:2427",
-          "Valuation": "25000",
-          "formatted_address": "9620 Arlene Dr, Anchorage, AK 99502, USA",
-          "lat": "61.1333546",
-          "lng": "-149.933364"
-        }
+        "Permit": "R22-1617",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "9620 ARLENE, Anchorage, Alaska",
+        "Parcel": "1241232000",
+        "Units": "0",
+        "Legal": "CAMPBELL LAKE HEIGHTS #10 BLK   2 LT  11  G:2427",
+        "Valuation": "25000",
+        "formatted_address": "9620 Arlene Dr, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -13376,21 +11396,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1618",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "3208 WOODLAND PARK, Anchorage, Alaska",
-          "Parcel": "1009105000",
-          "Units": "0",
-          "Legal": "WOODLAND PARK LT   5G  G:1628",
-          "Valuation": "22000",
-          "formatted_address": "3208 Woodland Park Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1909643",
-          "lng": "-149.9273875"
-        }
+        "Permit": "R22-1618",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "3208 WOODLAND PARK, Anchorage, Alaska",
+        "Parcel": "1009105000",
+        "Units": "0",
+        "Legal": "WOODLAND PARK LT   5G  G:1628",
+        "Valuation": "22000",
+        "formatted_address": "3208 Woodland Park Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -13403,21 +11419,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1709",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "5807 PERRY DRIVE, Anchorage, Alaska",
-          "Parcel": "616335000",
-          "Units": "0",
-          "Legal": "NUNAKA VALLEY BLK   Q LT  16  G:1438",
-          "Valuation": "13000",
-          "formatted_address": "5807 Perry Dr, Anchorage, AK 99504, USA",
-          "lat": "61.20641019999999",
-          "lng": "-149.7733349"
-        }
+        "Permit": "R22-1709",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "5807 PERRY DRIVE, Anchorage, Alaska",
+        "Parcel": "616335000",
+        "Units": "0",
+        "Legal": "NUNAKA VALLEY BLK   Q LT  16  G:1438",
+        "Valuation": "13000",
+        "formatted_address": "5807 Perry Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -13430,21 +11442,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1711",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "3259 AQUARIUS CIRCLE, Anchorage, Alaska",
-          "Parcel": "1007114000",
-          "Units": "0",
-          "Legal": "COLUMBIA PARK #5 BLK   2 LT  13  G:1626",
-          "Valuation": "12000",
-          "formatted_address": "3259 Aquarius Cir, Anchorage, AK 99517, USA",
-          "lat": "61.19019189999999",
-          "lng": "-149.9566805"
-        }
+        "Permit": "R22-1711",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "3259 AQUARIUS CIRCLE, Anchorage, Alaska",
+        "Parcel": "1007114000",
+        "Units": "0",
+        "Legal": "COLUMBIA PARK #5 BLK   2 LT  13  G:1626",
+        "Valuation": "12000",
+        "formatted_address": "3259 Aquarius Cir, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -13457,21 +11465,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1712",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "8901 TRAIL STREET, Anchorage, Alaska",
-          "Parcel": "1519226000",
-          "Units": "0",
-          "Legal": "TRAILS END BLK   5 LT   5  G:2641",
-          "Valuation": "32000",
-          "formatted_address": "8901 Trail St, Anchorage, AK 99507, USA",
-          "lat": "61.11791889999999",
-          "lng": "-149.7162996"
-        }
+        "Permit": "R22-1712",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "8901 TRAIL STREET, Anchorage, Alaska",
+        "Parcel": "1519226000",
+        "Units": "0",
+        "Legal": "TRAILS END BLK   5 LT   5  G:2641",
+        "Valuation": "32000",
+        "formatted_address": "8901 Trail St, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -13484,21 +11488,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1719",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "4030 COSMOS, Anchorage, Alaska",
-          "Parcel": "1006315000",
-          "Units": "0",
-          "Legal": "SATELLITE PARK #1 BLK   1 LT   8A  G:1625",
-          "Valuation": "19564",
-          "formatted_address": "4030 Cosmos Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1881658",
-          "lng": "-149.9617376"
-        }
+        "Permit": "R22-1719",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "4030 COSMOS, Anchorage, Alaska",
+        "Parcel": "1006315000",
+        "Units": "0",
+        "Legal": "SATELLITE PARK #1 BLK   1 LT   8A  G:1625",
+        "Valuation": "19564",
+        "formatted_address": "4030 Cosmos Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -13511,21 +11511,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1721",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "3230 ROSELLA, Anchorage, Alaska",
-          "Parcel": "718227000",
-          "Units": "0",
-          "Legal": "BAXTER HEIGHTS BLK   4 LT   7  G:1639",
-          "Valuation": "19186",
-          "formatted_address": "3230 Rosella St, Anchorage, AK 99504, USA",
-          "lat": "61.1911449",
-          "lng": "-149.7610874"
-        }
+        "Permit": "R22-1721",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "3230 ROSELLA, Anchorage, Alaska",
+        "Parcel": "718227000",
+        "Units": "0",
+        "Legal": "BAXTER HEIGHTS BLK   4 LT   7  G:1639",
+        "Valuation": "19186",
+        "formatted_address": "3230 Rosella St, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -13538,21 +11534,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1722",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "4801 SNOW CIRCLE, Anchorage, Alaska",
-          "Parcel": "631117000",
-          "Units": "0",
-          "Legal": "PINE VALLEY ESTATES BLK   1 LT   7  G:1537",
-          "Valuation": "19682",
-          "formatted_address": "4801 Snow Cir, Anchorage, AK 99508, USA",
-          "lat": "61.2014746",
-          "lng": "-149.7912975"
-        }
+        "Permit": "R22-1722",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "4801 SNOW CIRCLE, Anchorage, Alaska",
+        "Parcel": "631117000",
+        "Units": "0",
+        "Legal": "PINE VALLEY ESTATES BLK   1 LT   7  G:1537",
+        "Valuation": "19682",
+        "formatted_address": "4801 Snow Cir, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -13565,21 +11557,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1723",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "2524 BROOK HILL, Anchorage, Alaska",
-          "Parcel": "1617336000",
-          "Units": "0",
-          "Legal": "BROOKWOOD HILLS NORTH LT  36  G:2733",
-          "Valuation": "15007",
-          "formatted_address": "2524 Brook Hill Cir, Anchorage, AK 99516, USA",
-          "lat": "61.1142987",
-          "lng": "-149.8364008"
-        }
+        "Permit": "R22-1723",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "2524 BROOK HILL, Anchorage, Alaska",
+        "Parcel": "1617336000",
+        "Units": "0",
+        "Legal": "BROOKWOOD HILLS NORTH LT  36  G:2733",
+        "Valuation": "15007",
+        "formatted_address": "2524 Brook Hill Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -13592,21 +11580,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1724",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "3021 BRANDYWINE, Anchorage, Alaska",
-          "Parcel": "1216222000",
-          "Units": "0",
-          "Legal": "VILLAGE GREEN #3 BLK   3 LT   3  G:2127",
-          "Valuation": "20460",
-          "formatted_address": "3021 Brandywine Ave, Anchorage, AK 99502, USA",
-          "lat": "61.1553587",
-          "lng": "-149.9366683"
-        }
+        "Permit": "R22-1724",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "3021 BRANDYWINE, Anchorage, Alaska",
+        "Parcel": "1216222000",
+        "Units": "0",
+        "Legal": "VILLAGE GREEN #3 BLK   3 LT   3  G:2127",
+        "Valuation": "20460",
+        "formatted_address": "3021 Brandywine Ave, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -13619,21 +11603,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1727",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "2072 STANFORD, Anchorage, Alaska",
-          "Parcel": "321634000",
-          "Units": "0",
-          "Legal": "COLLEGE VILLAGE # 2 BLK  13 LT  11  G:1633",
-          "Valuation": "25708",
-          "formatted_address": "2072 Stanford Dr, Anchorage, AK 99508, USA",
-          "lat": "61.19257500000001",
-          "lng": "-149.8417669"
-        }
+        "Permit": "R22-1727",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "2072 STANFORD, Anchorage, Alaska",
+        "Parcel": "321634000",
+        "Units": "0",
+        "Legal": "COLLEGE VILLAGE # 2 BLK  13 LT  11  G:1633",
+        "Valuation": "25708",
+        "formatted_address": "2072 Stanford Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -13646,21 +11626,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1728",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "8101 WHITE DRIVE, Anchorage, Alaska",
-          "Parcel": "1509342000",
-          "Units": "0",
-          "Legal": "CONIFER HEIGHTS BLK   1 LT   6  G:2440",
-          "Valuation": "37395",
-          "formatted_address": "8101 White Dr, Anchorage, AK 99507, USA",
-          "lat": "61.136128",
-          "lng": "-149.7314582"
-        }
+        "Permit": "R22-1728",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "8101 WHITE DRIVE, Anchorage, Alaska",
+        "Parcel": "1509342000",
+        "Units": "0",
+        "Legal": "CONIFER HEIGHTS BLK   1 LT   6  G:2440",
+        "Valuation": "37395",
+        "formatted_address": "8101 White Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -13673,21 +11649,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1787",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "5/31/22",
-          "year": "2022",
-          "Address": "W 1331 80TH, Anchorage, Alaska",
-          "Parcel": "1220447000",
-          "Units": "0",
-          "Legal": "SHERWOOD ACRES #1 BLK   2 LT  24  G:2229",
-          "Valuation": "12800",
-          "formatted_address": "1331 W 80th Ave, Anchorage, AK 99518, USA",
-          "lat": "61.14893480000001",
-          "lng": "-149.9063095"
-        }
+        "Permit": "R22-1787",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "5/31/22",
+        "year": "2022",
+        "Address": "W 1331 80TH, Anchorage, Alaska",
+        "Parcel": "1220447000",
+        "Units": "0",
+        "Legal": "SHERWOOD ACRES #1 BLK   2 LT  24  G:2229",
+        "Valuation": "12800",
+        "formatted_address": "1331 W 80th Ave, Anchorage, AK 99518, USA"
       }
     },
     {
@@ -13700,21 +11672,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1837",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "1761 WESTVIEW, Anchorage, Alaska",
-          "Parcel": "620265000",
-          "Units": "0",
-          "Legal": "THE FOOTHILLS BLK   7 LT 36  G:1441",
-          "Valuation": "26159",
-          "formatted_address": "1761 Westview Cir, Anchorage, AK 99504, USA",
-          "lat": "61.20437499999999",
-          "lng": "-149.724902"
-        }
+        "Permit": "R22-1837",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "1761 WESTVIEW, Anchorage, Alaska",
+        "Parcel": "620265000",
+        "Units": "0",
+        "Legal": "THE FOOTHILLS BLK   7 LT 36  G:1441",
+        "Valuation": "26159",
+        "formatted_address": "1761 Westview Cir, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -13727,21 +11695,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1838",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "W 3420 30TH, Anchorage, Alaska",
-          "Parcel": "1004306000",
-          "Units": "0",
-          "Legal": "TURNAGAIN SOUTH BLK   6 LT  6  G:1626",
-          "Valuation": "16176",
-          "formatted_address": "3420 W 30th Ave, Anchorage, AK 99517, USA",
-          "lat": "61.1932353",
-          "lng": "-149.947806"
-        }
+        "Permit": "R22-1838",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "W 3420 30TH, Anchorage, Alaska",
+        "Parcel": "1004306000",
+        "Units": "0",
+        "Legal": "TURNAGAIN SOUTH BLK   6 LT  6  G:1626",
+        "Valuation": "16176",
+        "formatted_address": "3420 W 30th Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -13754,21 +11718,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1839",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "3406 GREENLAND, Anchorage, Alaska",
-          "Parcel": "1009744000",
-          "Units": "0",
-          "Legal": "WOODLAND PARK #2 BLK   7 LT  9  G:1628",
-          "Valuation": "23366",
-          "formatted_address": "3406 Greenland Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1890896",
-          "lng": "-149.9154492"
-        }
+        "Permit": "R22-1839",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "3406 GREENLAND, Anchorage, Alaska",
+        "Parcel": "1009744000",
+        "Units": "0",
+        "Legal": "WOODLAND PARK #2 BLK   7 LT  9  G:1628",
+        "Valuation": "23366",
+        "formatted_address": "3406 Greenland Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -13781,21 +11741,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1859",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "10720 SCHUSS, Anchorage, Alaska",
-          "Parcel": "1513483000",
-          "Units": "0",
-          "Legal": "PROSPECT HEIGHTS #2 BLK   7 LT  5  G:2540",
-          "Valuation": "30962",
-          "formatted_address": "10720 Schuss Dr, Anchorage, AK 99507, USA",
-          "lat": "61.12380880000001",
-          "lng": "-149.7355642"
-        }
+        "Permit": "R22-1859",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "10720 SCHUSS, Anchorage, Alaska",
+        "Parcel": "1513483000",
+        "Units": "0",
+        "Legal": "PROSPECT HEIGHTS #2 BLK   7 LT  5  G:2540",
+        "Valuation": "30962",
+        "formatted_address": "10720 Schuss Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -13808,21 +11764,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1860",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "811 HOWARD, Anchorage, Alaska",
-          "Parcel": "609732000",
-          "Units": "0",
-          "Legal": "HUNTWOOD PARK #2 BLK   2 LT 32  G:1339",
-          "Valuation": "18656",
-          "formatted_address": "811 Howard Cir, Anchorage, AK 99504, USA",
-          "lat": "61.2152395",
-          "lng": "-149.7519544"
-        }
+        "Permit": "R22-1860",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "811 HOWARD, Anchorage, Alaska",
+        "Parcel": "609732000",
+        "Units": "0",
+        "Legal": "HUNTWOOD PARK #2 BLK   2 LT 32  G:1339",
+        "Valuation": "18656",
+        "formatted_address": "811 Howard Cir, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -13835,21 +11787,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1861",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "10440 PRINCE WILLIAM CIRCLE, Anchorage, Alaska",
-          "Parcel": "1140286000",
-          "Units": "0",
-          "Legal": "RESOLUTIONPOINTE PH 1 BLK  3A LT 22  G:2525",
-          "Valuation": "19048",
-          "formatted_address": "10440 Prince William Cir, Anchorage, AK 99515, USA",
-          "lat": "61.1258107",
-          "lng": "-149.9569265"
-        }
+        "Permit": "R22-1861",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "10440 PRINCE WILLIAM CIRCLE, Anchorage, Alaska",
+        "Parcel": "1140286000",
+        "Units": "0",
+        "Legal": "RESOLUTIONPOINTE PH 1 BLK  3A LT 22  G:2525",
+        "Valuation": "19048",
+        "formatted_address": "10440 Prince William Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -13862,21 +11810,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1862",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "2530 BANBURY, Anchorage, Alaska",
-          "Parcel": "638333000",
-          "Units": "0",
-          "Legal": "FOXHALL #4 BLK   4 LT 34  G:1539",
-          "Valuation": "15112",
-          "formatted_address": "2530 Banbury Dr, Anchorage, AK 99504, USA",
-          "lat": "61.1977005",
-          "lng": "-149.7503367"
-        }
+        "Permit": "R22-1862",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "2530 BANBURY, Anchorage, Alaska",
+        "Parcel": "638333000",
+        "Units": "0",
+        "Legal": "FOXHALL #4 BLK   4 LT 34  G:1539",
+        "Valuation": "15112",
+        "formatted_address": "2530 Banbury Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -13889,21 +11833,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1863",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "6730 REEDYKE, Anchorage, Alaska",
-          "Parcel": "1406313000",
-          "Units": "0",
-          "Legal": "O'BRIEN ACRES LT  13  G:2034",
-          "Valuation": "7562",
-          "formatted_address": "6730 Reedyke Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1599177",
-          "lng": "-149.829948"
-        }
+        "Permit": "R22-1863",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "6730 REEDYKE, Anchorage, Alaska",
+        "Parcel": "1406313000",
+        "Units": "0",
+        "Legal": "O'BRIEN ACRES LT  13  G:2034",
+        "Valuation": "7562",
+        "formatted_address": "6730 Reedyke Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -13916,21 +11856,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1864",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "911 R STREET, Anchorage, Alaska",
-          "Parcel": "107219000",
-          "Units": "0",
-          "Legal": "L STREET SLIDE REPLAT PHASE 2 BLK  13A LT2A  G:1328",
-          "Valuation": "14757",
-          "formatted_address": "911 R St, Anchorage, AK 99501, USA",
-          "lat": "61.21335800000001",
-          "lng": "-149.9133252"
-        }
+        "Permit": "R22-1864",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "911 R STREET, Anchorage, Alaska",
+        "Parcel": "107219000",
+        "Units": "0",
+        "Legal": "L STREET SLIDE REPLAT PHASE 2 BLK  13A LT2A  G:1328",
+        "Valuation": "14757",
+        "formatted_address": "911 R St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -13943,21 +11879,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1865",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "2020 SHORE DRIVE, Anchorage, Alaska",
-          "Parcel": "1910159000",
-          "Units": "0",
-          "Legal": "SHORE CREST BLK   3 LT  7  G:2728",
-          "Valuation": "16856",
-          "formatted_address": "2020 Shore Dr, Anchorage, AK 99515, USA",
-          "lat": "61.1105475",
-          "lng": "-149.9172935"
-        }
+        "Permit": "R22-1865",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "2020 SHORE DRIVE, Anchorage, Alaska",
+        "Parcel": "1910159000",
+        "Units": "0",
+        "Legal": "SHORE CREST BLK   3 LT  7  G:2728",
+        "Valuation": "16856",
+        "formatted_address": "2020 Shore Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -13970,21 +11902,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1867",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "W 517 15TH, Anchorage, Alaska",
-          "Parcel": "215511000",
-          "Units": "0",
-          "Legal": "SOUTH ADDITION BLK  38C LT  10  G:1430",
-          "Valuation": "12648",
-          "formatted_address": "517 E 15th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2079755",
-          "lng": "-149.8742832"
-        }
+        "Permit": "R22-1867",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "W 517 15TH, Anchorage, Alaska",
+        "Parcel": "215511000",
+        "Units": "0",
+        "Legal": "SOUTH ADDITION BLK  38C LT  10  G:1430",
+        "Valuation": "12648",
+        "formatted_address": "517 E 15th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -13997,21 +11925,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1868",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "7705 PORT ORFORD, Anchorage, Alaska",
-          "Parcel": "1509353000",
-          "Units": "0",
-          "Legal": "CONIFER HEIGHTS BLK   1 LT 23  G:2440",
-          "Valuation": "20713",
-          "formatted_address": "7705 Port Orford Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1362645",
-          "lng": "-149.740594"
-        }
+        "Permit": "R22-1868",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "7705 PORT ORFORD, Anchorage, Alaska",
+        "Parcel": "1509353000",
+        "Units": "0",
+        "Legal": "CONIFER HEIGHTS BLK   1 LT 23  G:2440",
+        "Valuation": "20713",
+        "formatted_address": "7705 Port Orford Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -14024,21 +11948,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1869",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "8540 CORMORANT COVE, Anchorage, Alaska",
-          "Parcel": "1501618000",
-          "Units": "0",
-          "Legal": "SAHALEE PHASE 3 BLK   2 LT 50  G:2336",
-          "Valuation": "13656",
-          "formatted_address": "8540 Cormorant Cove Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1431158",
-          "lng": "-149.7909042"
-        }
+        "Permit": "R22-1869",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "8540 CORMORANT COVE, Anchorage, Alaska",
+        "Parcel": "1501618000",
+        "Units": "0",
+        "Legal": "SAHALEE PHASE 3 BLK   2 LT 50  G:2336",
+        "Valuation": "13656",
+        "formatted_address": "8540 Cormorant Cove Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -14051,21 +11971,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1870",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "9650 BRIEN STREET, Anchorage, Alaska",
-          "Parcel": "1506118000",
-          "Units": "0",
-          "Legal": "CRESTWOOD LT  16  G:2438",
-          "Valuation": "21830",
-          "formatted_address": "9650 Brien St, Anchorage, AK 99507, USA",
-          "lat": "61.1331465",
-          "lng": "-149.7702676"
-        }
+        "Permit": "R22-1870",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "9650 BRIEN STREET, Anchorage, Alaska",
+        "Parcel": "1506118000",
+        "Units": "0",
+        "Legal": "CRESTWOOD LT  16  G:2438",
+        "Valuation": "21830",
+        "formatted_address": "9650 Brien St, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -14078,21 +11994,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1871",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "11139 BULWARK, Anchorage, Alaska",
-          "Parcel": "1916315000",
-          "Units": "0",
-          "Legal": "LOOKOUT LANDING PHASE 3 BLK   2 LT 31  G:2627",
-          "Valuation": "15832",
-          "formatted_address": "11139 Bulwark Cir, Anchorage, AK 99515, USA",
-          "lat": "61.1199254",
-          "lng": "-149.9278086"
-        }
+        "Permit": "R22-1871",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "11139 BULWARK, Anchorage, Alaska",
+        "Parcel": "1916315000",
+        "Units": "0",
+        "Legal": "LOOKOUT LANDING PHASE 3 BLK   2 LT 31  G:2627",
+        "Valuation": "15832",
+        "formatted_address": "11139 Bulwark Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -14105,21 +12017,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1969",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "7310 SETTER DRIVE, Anchorage, Alaska",
-          "Parcel": "1107369000",
-          "Units": "0",
-          "Legal": "SPORTSMENSPOINT #3 BLK   4 LT 24A  G:2124",
-          "Valuation": "23000",
-          "formatted_address": "7310 Setter Dr, Anchorage, AK 99502, USA",
-          "lat": "61.1544085",
-          "lng": "-149.9740075"
-        }
+        "Permit": "R22-1969",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "7310 SETTER DRIVE, Anchorage, Alaska",
+        "Parcel": "1107369000",
+        "Units": "0",
+        "Legal": "SPORTSMENSPOINT #3 BLK   4 LT 24A  G:2124",
+        "Valuation": "23000",
+        "formatted_address": "7310 Setter Dr, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -14132,21 +12040,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1970",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "10613 BRIGANTINE CIRCLE, Anchorage, Alaska",
-          "Parcel": "1254366000",
-          "Units": "0",
-          "Legal": "MARINER POINT AT SOUTHPORT PH3 BLK   1 LT 13  G:2527",
-          "Valuation": "23000",
-          "formatted_address": "10613 Brigantine Cir, Anchorage, AK 99515, USA",
-          "lat": "61.1243531",
-          "lng": "-149.930496"
-        }
+        "Permit": "R22-1970",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "10613 BRIGANTINE CIRCLE, Anchorage, Alaska",
+        "Parcel": "1254366000",
+        "Units": "0",
+        "Legal": "MARINER POINT AT SOUTHPORT PH3 BLK   1 LT 13  G:2527",
+        "Valuation": "23000",
+        "formatted_address": "10613 Brigantine Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -14159,21 +12063,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-1971",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "3640 DORA, Anchorage, Alaska",
-          "Parcel": "1833208000",
-          "Units": "0",
-          "Legal": "T12N R3W SEC 33 LT 226  G:3135",
-          "Valuation": "26000",
-          "formatted_address": "3640 Dora Ave, Anchorage, AK 99516, USA",
-          "lat": "61.08104720000001",
-          "lng": "-149.8141591"
-        }
+        "Permit": "R22-1971",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "3640 DORA, Anchorage, Alaska",
+        "Parcel": "1833208000",
+        "Units": "0",
+        "Legal": "T12N R3W SEC 33 LT 226  G:3135",
+        "Valuation": "26000",
+        "formatted_address": "3640 Dora Ave, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -14186,21 +12086,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2009",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "4808 BUCKINGHAM, Anchorage, Alaska",
-          "Parcel": "1033434000",
-          "Units": "0",
-          "Legal": "WINDEMERE BLK   4 LT  3  G:1829",
-          "Valuation": "17000",
-          "formatted_address": "4808 Buckingham Way, Anchorage, AK 99503, USA",
-          "lat": "61.1757512",
-          "lng": "-149.906603"
-        }
+        "Permit": "R22-2009",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "4808 BUCKINGHAM, Anchorage, Alaska",
+        "Parcel": "1033434000",
+        "Units": "0",
+        "Legal": "WINDEMERE BLK   4 LT  3  G:1829",
+        "Valuation": "17000",
+        "formatted_address": "4808 Buckingham Way, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -14213,21 +12109,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2010",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "14495 OLD SEWARD, Anchorage, Alaska",
-          "Parcel": "1824127000",
-          "Units": "0",
-          "Legal": "TURNAGAIN PARK #2 BLK   2 LT  2  G:3033",
-          "Valuation": "45869",
-          "formatted_address": "14495 Old Seward Hwy, Anchorage, AK 99515, USA",
-          "lat": "61.0896784",
-          "lng": "-149.8372035"
-        }
+        "Permit": "R22-2010",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "14495 OLD SEWARD, Anchorage, Alaska",
+        "Parcel": "1824127000",
+        "Units": "0",
+        "Legal": "TURNAGAIN PARK #2 BLK   2 LT  2  G:3033",
+        "Valuation": "45869",
+        "formatted_address": "14495 Old Seward Hwy, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -14240,21 +12132,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2025",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/22",
-          "year": "2022",
-          "Address": "1801 SUNRISE, Anchorage, Alaska",
-          "Parcel": "414110000",
-          "Units": "0",
-          "Legal": "SAXTON BLK   8 LT 12  G:1434",
-          "Valuation": "11470",
-          "formatted_address": "1801 Sunrise Dr, Anchorage, AK 99508, USA",
-          "lat": "61.2042215",
-          "lng": "-149.8256721"
-        }
+        "Permit": "R22-2025",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/22",
+        "year": "2022",
+        "Address": "1801 SUNRISE, Anchorage, Alaska",
+        "Parcel": "414110000",
+        "Units": "0",
+        "Legal": "SAXTON BLK   8 LT 12  G:1434",
+        "Valuation": "11470",
+        "formatted_address": "1801 Sunrise Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -14267,21 +12155,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C22-1762",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "6407 ARCTIC SPUR, Anchorage, Alaska",
-          "Parcel": "1202140000",
-          "Units": "0",
-          "Legal": "ARCTIC INDUSTRIAL #2 BLK   1 LTS  3 & 4  G:2029",
-          "Valuation": "18200",
-          "formatted_address": "6407 Arctic Spur Rd, Anchorage, AK 99518, USA",
-          "lat": "61.1629357",
-          "lng": "-149.8951159"
-        }
+        "Permit": "C22-1762",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "6407 ARCTIC SPUR, Anchorage, Alaska",
+        "Parcel": "1202140000",
+        "Units": "0",
+        "Legal": "ARCTIC INDUSTRIAL #2 BLK   1 LTS  3 & 4  G:2029",
+        "Valuation": "18200",
+        "formatted_address": "6407 Arctic Spur Rd, Anchorage, AK 99518, USA"
       }
     },
     {
@@ -14294,21 +12178,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2057",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "6672 O'BRIEN, Anchorage, Alaska",
-          "Parcel": "1405413000",
-          "Units": "0",
-          "Legal": "GALATEA ESTATES BLK   8 LT 10  G:2033",
-          "Valuation": "12325",
-          "formatted_address": "6672 O'Brien St, Anchorage, AK 99507, USA",
-          "lat": "61.16029099999999",
-          "lng": "-149.8367693"
-        }
+        "Permit": "R22-2057",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "6672 O'BRIEN, Anchorage, Alaska",
+        "Parcel": "1405413000",
+        "Units": "0",
+        "Legal": "GALATEA ESTATES BLK   8 LT 10  G:2033",
+        "Valuation": "12325",
+        "formatted_address": "6672 O'Brien St, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -14321,21 +12201,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2058",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "6670 O'BRIEN, Anchorage, Alaska",
-          "Parcel": "1405413000",
-          "Units": "0",
-          "Legal": "GALATEA ESTATES BLK   8 LT 10  G:2033",
-          "Valuation": "12325",
-          "formatted_address": "6670 O'Brien St, Anchorage, AK 99507, USA",
-          "lat": "61.1603007",
-          "lng": "-149.8369201"
-        }
+        "Permit": "R22-2058",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "6670 O'BRIEN, Anchorage, Alaska",
+        "Parcel": "1405413000",
+        "Units": "0",
+        "Legal": "GALATEA ESTATES BLK   8 LT 10  G:2033",
+        "Valuation": "12325",
+        "formatted_address": "6670 O'Brien St, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -14348,21 +12224,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2059",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "3148 DISCOVERY BAY, Anchorage, Alaska",
-          "Parcel": "1917114000",
-          "Units": "0",
-          "Legal": "DISCOVERY HEIGHTS PHASE 2 BLK   3 LT  2  G:2626",
-          "Valuation": "32168",
-          "formatted_address": "3148 Discovery Bay Dr, Anchorage, AK 99515, USA",
-          "lat": "61.1177998",
-          "lng": "-149.9389944"
-        }
+        "Permit": "R22-2059",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "3148 DISCOVERY BAY, Anchorage, Alaska",
+        "Parcel": "1917114000",
+        "Units": "0",
+        "Legal": "DISCOVERY HEIGHTS PHASE 2 BLK   3 LT  2  G:2626",
+        "Valuation": "32168",
+        "formatted_address": "3148 Discovery Bay Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -14375,21 +12247,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2081",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "2555 MARITIME LOOP, Anchorage, Alaska",
-          "Parcel": "1253330000",
-          "Units": "0",
-          "Legal": "HIDDEN COVE PH 3 LT  30  G:2527",
-          "Valuation": "19425",
-          "formatted_address": "2555 Maritime Loop, Anchorage, AK 99515, USA",
-          "lat": "61.12910129999999",
-          "lng": "-149.925845"
-        }
+        "Permit": "R22-2081",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "2555 MARITIME LOOP, Anchorage, Alaska",
+        "Parcel": "1253330000",
+        "Units": "0",
+        "Legal": "HIDDEN COVE PH 3 LT  30  G:2527",
+        "Valuation": "19425",
+        "formatted_address": "2555 Maritime Loop, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -14402,21 +12270,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2120",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "9110 TERI CIRCLE, Anchorage, Alaska",
-          "Parcel": "4103154000",
-          "Units": "0",
-          "Legal": "KNOLL ON THE WOLD BLK   1 LT  3  G:2142",
-          "Valuation": "13905",
-          "formatted_address": "9110 Teri Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1530157",
-          "lng": "-149.7120963"
-        }
+        "Permit": "R22-2120",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "9110 TERI CIRCLE, Anchorage, Alaska",
+        "Parcel": "4103154000",
+        "Units": "0",
+        "Legal": "KNOLL ON THE WOLD BLK   1 LT  3  G:2142",
+        "Valuation": "13905",
+        "formatted_address": "9110 Teri Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -14429,21 +12293,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2121",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "11361 MAEL STREET, Anchorage, Alaska",
-          "Parcel": "1549104000",
-          "Units": "0",
-          "Legal": "T12N R3W SEC 23 S2NE4SE4NW4 PARCEL 25A G:2638",
-          "Valuation": "20713",
-          "formatted_address": "11361 Mael St, Anchorage, AK 99516, USA",
-          "lat": "61.1181654",
-          "lng": "-149.7616203"
-        }
+        "Permit": "R22-2121",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "11361 MAEL STREET, Anchorage, Alaska",
+        "Parcel": "1549104000",
+        "Units": "0",
+        "Legal": "T12N R3W SEC 23 S2NE4SE4NW4 PARCEL 25A G:2638",
+        "Valuation": "20713",
+        "formatted_address": "11361 Mael St, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -14456,21 +12316,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2122",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "9571 MIDDEN, Anchorage, Alaska",
-          "Parcel": "4103112000",
-          "Units": "0",
-          "Legal": "TAIGA LT   3  G:2143",
-          "Valuation": "17428",
-          "formatted_address": "9571 Midden Way, Anchorage, AK 99507, USA",
-          "lat": "61.1525877",
-          "lng": "-149.6992832"
-        }
+        "Permit": "R22-2122",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "9571 MIDDEN, Anchorage, Alaska",
+        "Parcel": "4103112000",
+        "Units": "0",
+        "Legal": "TAIGA LT   3  G:2143",
+        "Valuation": "17428",
+        "formatted_address": "9571 Midden Way, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -14483,21 +12339,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2123",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "3431 COTTONWOOD, Anchorage, Alaska",
-          "Parcel": "323160000",
-          "Units": "0",
-          "Legal": "COLLEGE VILLAGE #13 BLK  31 LT 17  G:1632",
-          "Valuation": "15336",
-          "formatted_address": "3431 Cottonwood St, Anchorage, AK 99508, USA",
-          "lat": "61.1891486",
-          "lng": "-149.8552249"
-        }
+        "Permit": "R22-2123",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "3431 COTTONWOOD, Anchorage, Alaska",
+        "Parcel": "323160000",
+        "Units": "0",
+        "Legal": "COLLEGE VILLAGE #13 BLK  31 LT 17  G:1632",
+        "Valuation": "15336",
+        "formatted_address": "3431 Cottonwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -14510,21 +12362,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2124",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "9300 NORDIC, Anchorage, Alaska",
-          "Parcel": "1509340000",
-          "Units": "0",
-          "Legal": "CONIFER HEIGHTS BLK   1 LT  2  G:2440",
-          "Valuation": "27204",
-          "formatted_address": "9300 Nordic St, Anchorage, AK 99507, USA",
-          "lat": "61.13680369999999",
-          "lng": "-149.7301108"
-        }
+        "Permit": "R22-2124",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "9300 NORDIC, Anchorage, Alaska",
+        "Parcel": "1509340000",
+        "Units": "0",
+        "Legal": "CONIFER HEIGHTS BLK   1 LT  2  G:2440",
+        "Valuation": "27204",
+        "formatted_address": "9300 Nordic St, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -14537,21 +12385,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2125",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "W 1641 14TH, Anchorage, Alaska",
-          "Parcel": "110227000",
-          "Units": "0",
-          "Legal": "SOUTH ADDITION BLK  33A LT7C  G:1428",
-          "Valuation": "24509",
-          "formatted_address": "1641 W 14th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.20885589999999",
-          "lng": "-149.915545"
-        }
+        "Permit": "R22-2125",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "W 1641 14TH, Anchorage, Alaska",
+        "Parcel": "110227000",
+        "Units": "0",
+        "Legal": "SOUTH ADDITION BLK  33A LT7C  G:1428",
+        "Valuation": "24509",
+        "formatted_address": "1641 W 14th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -14564,21 +12408,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2126",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "11840 WOODBOURNE, Anchorage, Alaska",
-          "Parcel": "1535114000",
-          "Units": "0",
-          "Legal": "WOODBOURNE BLK   1 LT  8  G:2741",
-          "Valuation": "23392",
-          "formatted_address": "11840 Woodbourne Dr, Anchorage, AK 99516, USA",
-          "lat": "61.1133537",
-          "lng": "-149.7233269"
-        }
+        "Permit": "R22-2126",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "11840 WOODBOURNE, Anchorage, Alaska",
+        "Parcel": "1535114000",
+        "Units": "0",
+        "Legal": "WOODBOURNE BLK   1 LT  8  G:2741",
+        "Valuation": "23392",
+        "formatted_address": "11840 Woodbourne Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -14591,21 +12431,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2127",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "2143 CHURCHILL DRIVE, Anchorage, Alaska",
-          "Parcel": "124335000",
-          "Units": "0",
-          "Legal": "HUNTINGTONPARK #1 BLK   2 LT 10B  G:1528",
-          "Valuation": "18456",
-          "formatted_address": "2143 Churchill Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1963478",
-          "lng": "-149.9255653"
-        }
+        "Permit": "R22-2127",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "2143 CHURCHILL DRIVE, Anchorage, Alaska",
+        "Parcel": "124335000",
+        "Units": "0",
+        "Legal": "HUNTINGTONPARK #1 BLK   2 LT 10B  G:1528",
+        "Valuation": "18456",
+        "formatted_address": "2143 Churchill Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -14618,21 +12454,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2128",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "1152 NORTHPOINTE BLUFF, Anchorage, Alaska",
-          "Parcel": "302130000",
-          "Units": "0",
-          "Legal": "NORTHPOINTE BLUFF BLK   1 LT 16 NORTHPOINTE BLUFF PLANNED COMM G:1132",
-          "Valuation": "32235",
-          "formatted_address": "1152 Northpointe Bluff Dr, Anchorage, AK 99501, USA",
-          "lat": "61.227976",
-          "lng": "-149.8625378"
-        }
+        "Permit": "R22-2128",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "1152 NORTHPOINTE BLUFF, Anchorage, Alaska",
+        "Parcel": "302130000",
+        "Units": "0",
+        "Legal": "NORTHPOINTE BLUFF BLK   1 LT 16 NORTHPOINTE BLUFF PLANNED COMM G:1132",
+        "Valuation": "32235",
+        "formatted_address": "1152 Northpointe Bluff Dr, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -14645,21 +12477,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2129",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "13700 JARVI, Anchorage, Alaska",
-          "Parcel": "1815109000",
-          "Units": "0",
-          "Legal": "SUNSET MANOR #2 BLK   6 LT  4  G:2932",
-          "Valuation": "10316",
-          "formatted_address": "13700 Jarvi Dr, Anchorage, AK 99515, USA",
-          "lat": "61.0958792",
-          "lng": "-149.8553052"
-        }
+        "Permit": "R22-2129",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "13700 JARVI, Anchorage, Alaska",
+        "Parcel": "1815109000",
+        "Units": "0",
+        "Legal": "SUNSET MANOR #2 BLK   6 LT  4  G:2932",
+        "Valuation": "10316",
+        "formatted_address": "13700 Jarvi Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -14672,21 +12500,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2130",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "6900 CRAWFORD STREET, Anchorage, Alaska",
-          "Parcel": "1108408000",
-          "Units": "0",
-          "Legal": "TERRACE ONTHE LAKE BLK   4 LT  5  G:2125",
-          "Valuation": "29605",
-          "formatted_address": "6900 Crawford St, Anchorage, AK 99502, USA",
-          "lat": "61.15822859999999",
-          "lng": "-149.9615336"
-        }
+        "Permit": "R22-2130",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "6900 CRAWFORD STREET, Anchorage, Alaska",
+        "Parcel": "1108408000",
+        "Units": "0",
+        "Legal": "TERRACE ONTHE LAKE BLK   4 LT  5  G:2125",
+        "Valuation": "29605",
+        "formatted_address": "6900 Crawford St, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -14699,21 +12523,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2131",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "6500 DOWNEY FINCH, Anchorage, Alaska",
-          "Parcel": "1523451000",
-          "Units": "0",
-          "Legal": "ALPINE WOODS BLK   6 LT 10  G:2738",
-          "Valuation": "38662",
-          "formatted_address": "6500 Downey Finch Dr, Anchorage, AK 99516, USA",
-          "lat": "61.1097629",
-          "lng": "-149.7603301"
-        }
+        "Permit": "R22-2131",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "6500 DOWNEY FINCH, Anchorage, Alaska",
+        "Parcel": "1523451000",
+        "Units": "0",
+        "Legal": "ALPINE WOODS BLK   6 LT 10  G:2738",
+        "Valuation": "38662",
+        "formatted_address": "6500 Downey Finch Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -14726,21 +12546,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2156",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "3409 WYOMING, Anchorage, Alaska",
-          "Parcel": "1009706000",
-          "Units": "0",
-          "Legal": "WOODLAND PARK #2 BLK   7 LT 25  G:1628",
-          "Valuation": "23366",
-          "formatted_address": "3409 Wyoming Dr, Anchorage, AK 99517, USA",
-          "lat": "61.18892040000001",
-          "lng": "-149.9161986"
-        }
+        "Permit": "R22-2156",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "3409 WYOMING, Anchorage, Alaska",
+        "Parcel": "1009706000",
+        "Units": "0",
+        "Legal": "WOODLAND PARK #2 BLK   7 LT 25  G:1628",
+        "Valuation": "23366",
+        "formatted_address": "3409 Wyoming Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -14753,21 +12569,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2157",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "2943 CAPTAIN COOK ESTATES, Anchorage, Alaska",
-          "Parcel": "1002253000",
-          "Units": "0",
-          "Legal": "CAPTAIN COOK ESTATES LT  12  G:1628",
-          "Valuation": "31877",
-          "formatted_address": "2943 Captain Cook Estates Cir, Anchorage, AK 99517, USA",
-          "lat": "61.1936295",
-          "lng": "-149.9257757"
-        }
+        "Permit": "R22-2157",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "2943 CAPTAIN COOK ESTATES, Anchorage, Alaska",
+        "Parcel": "1002253000",
+        "Units": "0",
+        "Legal": "CAPTAIN COOK ESTATES LT  12  G:1628",
+        "Valuation": "31877",
+        "formatted_address": "2943 Captain Cook Estates Cir, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -14780,21 +12592,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2198",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "15741 STANWOOD, Anchorage, Alaska",
-          "Parcel": "2050229000",
-          "Units": "0",
-          "Legal": "SOUTHPARK #2 BLK   3 LT 31  G:3236",
-          "Valuation": "27000",
-          "formatted_address": "15741 Stanwood Cir, Anchorage, AK 99516, USA",
-          "lat": "61.07628509999999",
-          "lng": "-149.7942554"
-        }
+        "Permit": "R22-2198",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "15741 STANWOOD, Anchorage, Alaska",
+        "Parcel": "2050229000",
+        "Units": "0",
+        "Legal": "SOUTHPARK #2 BLK   3 LT 31  G:3236",
+        "Valuation": "27000",
+        "formatted_address": "15741 Stanwood Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -14807,21 +12615,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2199",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "2620 PORTER PLACE, Anchorage, Alaska",
-          "Parcel": "416333000",
-          "Units": "0",
-          "Legal": "ANCHOR PARK BLK   3 LT  7  G:1534",
-          "Valuation": "25000",
-          "formatted_address": "2620 Porter Pl, Anchorage, AK 99508, USA",
-          "lat": "61.19702780000001",
-          "lng": "-149.8359922"
-        }
+        "Permit": "R22-2199",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "2620 PORTER PLACE, Anchorage, Alaska",
+        "Parcel": "416333000",
+        "Units": "0",
+        "Legal": "ANCHOR PARK BLK   3 LT  7  G:1534",
+        "Valuation": "25000",
+        "formatted_address": "2620 Porter Pl, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -14834,21 +12638,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2244",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "12931 MICHAEL STREET, Anchorage, Alaska",
-          "Parcel": "1740109000",
-          "Units": "0",
-          "Legal": "MOUNTAIN SHADOWS BLK   1 LT  9  G:2841",
-          "Valuation": "11140",
-          "formatted_address": "Anchorage, AK, USA",
-          "lat": "61.2175758",
-          "lng": "-149.8996785"
-        }
+        "Permit": "R22-2244",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "12931 MICHAEL STREET, Anchorage, Alaska",
+        "Parcel": "1740109000",
+        "Units": "0",
+        "Legal": "MOUNTAIN SHADOWS BLK   1 LT  9  G:2841",
+        "Valuation": "11140",
+        "formatted_address": "Anchorage, AK, USA"
       }
     },
     {
@@ -14861,21 +12661,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2246",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "2201 FOREST PARK, Anchorage, Alaska",
-          "Parcel": "117507000",
-          "Units": "0",
-          "Legal": "PARK LANE LT   4  G:1528",
-          "Valuation": "8059",
-          "formatted_address": "2201 Forest Park Dr, Anchorage, AK 99517, USA",
-          "lat": "61.20088049999999",
-          "lng": "-149.92762629999999"
-        }
+        "Permit": "R22-2246",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "2201 FOREST PARK, Anchorage, Alaska",
+        "Parcel": "117507000",
+        "Units": "0",
+        "Legal": "PARK LANE LT   4  G:1528",
+        "Valuation": "8059",
+        "formatted_address": "2201 Forest Park Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -14888,21 +12684,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2247",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "5654 YUKON CHARLIE LOOP, Anchorage, Alaska",
-          "Parcel": "1131256000",
-          "Units": "0",
-          "Legal": "WESTPARK ADDN 5 BLK  10 LT 16  G:2223",
-          "Valuation": "10707",
-          "formatted_address": "5654 Yukon Charlie Loop, Anchorage, AK 99502, USA",
-          "lat": "61.1503818",
-          "lng": "-149.9844748"
-        }
+        "Permit": "R22-2247",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "5654 YUKON CHARLIE LOOP, Anchorage, Alaska",
+        "Parcel": "1131256000",
+        "Units": "0",
+        "Legal": "WESTPARK ADDN 5 BLK  10 LT 16  G:2223",
+        "Valuation": "10707",
+        "formatted_address": "5654 Yukon Charlie Loop, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -14915,21 +12707,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2248",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "6201 BUBBLING BROOK, Anchorage, Alaska",
-          "Parcel": "1549205000",
-          "Units": "0",
-          "Legal": "SHADOWBROOK LT   4  G:2638",
-          "Valuation": "15268",
-          "formatted_address": "6201 Bubbling Brook Cir, Anchorage, AK 99516, USA",
-          "lat": "61.1179248",
-          "lng": "-149.7660548"
-        }
+        "Permit": "R22-2248",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "6201 BUBBLING BROOK, Anchorage, Alaska",
+        "Parcel": "1549205000",
+        "Units": "0",
+        "Legal": "SHADOWBROOK LT   4  G:2638",
+        "Valuation": "15268",
+        "formatted_address": "6201 Bubbling Brook Cir, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -14942,21 +12730,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2249",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "7/31/22",
-          "year": "2022",
-          "Address": "7100 MONTAGNE, Anchorage, Alaska",
-          "Parcel": "4103139000",
-          "Units": "0",
-          "Legal": "ATELIER #1 BLK   3 LT  3  G:2142",
-          "Valuation": "16276",
-          "formatted_address": "7100 Montagne Cir, Anchorage, AK 99507, USA",
-          "lat": "61.15670350000001",
-          "lng": "-149.7132996"
-        }
+        "Permit": "R22-2249",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "7/31/22",
+        "year": "2022",
+        "Address": "7100 MONTAGNE, Anchorage, Alaska",
+        "Parcel": "4103139000",
+        "Units": "0",
+        "Legal": "ATELIER #1 BLK   3 LT  3  G:2142",
+        "Valuation": "16276",
+        "formatted_address": "7100 Montagne Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -14969,21 +12753,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2334",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/22",
-          "year": "2022",
-          "Address": "12930 LINDSEY, Anchorage, Alaska",
-          "Parcel": "1735285000",
-          "Units": "0",
-          "Legal": "KEMPTON PARK BLK   1 LT  8  G:2834",
-          "Valuation": "24975",
-          "formatted_address": "Lindsey Dr, Anchorage, AK 99516, USA",
-          "lat": "61.1031312",
-          "lng": "-149.8203774"
-        }
+        "Permit": "R22-2334",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/22",
+        "year": "2022",
+        "Address": "12930 LINDSEY, Anchorage, Alaska",
+        "Parcel": "1735285000",
+        "Units": "0",
+        "Legal": "KEMPTON PARK BLK   1 LT  8  G:2834",
+        "Valuation": "24975",
+        "formatted_address": "Lindsey Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -14996,21 +12776,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2357",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/22",
-          "year": "2022",
-          "Address": "W 720 19TH, Anchorage, Alaska",
-          "Parcel": "218403000",
-          "Units": "0",
-          "Legal": "CENTER BLK   3 LT  6  G:1430",
-          "Valuation": "22584",
-          "formatted_address": "720 W 19th Ave, Anchorage, AK 99503, USA",
-          "lat": "61.2029446",
-          "lng": "-149.8966053"
-        }
+        "Permit": "R22-2357",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/22",
+        "year": "2022",
+        "Address": "W 720 19TH, Anchorage, Alaska",
+        "Parcel": "218403000",
+        "Units": "0",
+        "Legal": "CENTER BLK   3 LT  6  G:1430",
+        "Valuation": "22584",
+        "formatted_address": "720 W 19th Ave, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -15023,21 +12799,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2378",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "8/31/22",
-          "year": "2022",
-          "Address": "9000 SAHALEE, Anchorage, Alaska",
-          "Parcel": "1504410000",
-          "Units": "0",
-          "Legal": "SAHALEE BLK   1 LT 21  G:2336",
-          "Valuation": "17503",
-          "formatted_address": "9000 Sahalee Dr, Anchorage, AK 99507, USA",
-          "lat": "61.13951659999999",
-          "lng": "-149.7932733"
-        }
+        "Permit": "R22-2378",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "8/31/22",
+        "year": "2022",
+        "Address": "9000 SAHALEE, Anchorage, Alaska",
+        "Parcel": "1504410000",
+        "Units": "0",
+        "Legal": "SAHALEE BLK   1 LT 21  G:2336",
+        "Valuation": "17503",
+        "formatted_address": "9000 Sahalee Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -15050,21 +12822,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2379",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "8/31/22",
-          "year": "2022",
-          "Address": "5412 SKYLARK AVENUE, Anchorage, Alaska",
-          "Parcel": "1111295000",
-          "Units": "0",
-          "Legal": "M-W BLK   2 LT  2A  G:2224",
-          "Valuation": "29489",
-          "formatted_address": "5412 Skylark Ave, Anchorage, AK 99502, USA",
-          "lat": "61.1512959",
-          "lng": "-149.9804898"
-        }
+        "Permit": "R22-2379",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "8/31/22",
+        "year": "2022",
+        "Address": "5412 SKYLARK AVENUE, Anchorage, Alaska",
+        "Parcel": "1111295000",
+        "Units": "0",
+        "Legal": "M-W BLK   2 LT  2A  G:2224",
+        "Valuation": "29489",
+        "formatted_address": "5412 Skylark Ave, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -15077,21 +12845,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2398",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "8/31/22",
-          "year": "2022",
-          "Address": "4715 BLUE HERON CIRCLE, Anchorage, Alaska",
-          "Parcel": "1504458000",
-          "Units": "0",
-          "Legal": "SAHALEE PH4 BLK   1 LT 29  G:2336",
-          "Valuation": "58960",
-          "formatted_address": "4715 Blue Heron Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1385014",
-          "lng": "-149.7950854"
-        }
+        "Permit": "R22-2398",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "8/31/22",
+        "year": "2022",
+        "Address": "4715 BLUE HERON CIRCLE, Anchorage, Alaska",
+        "Parcel": "1504458000",
+        "Units": "0",
+        "Legal": "SAHALEE PH4 BLK   1 LT 29  G:2336",
+        "Valuation": "58960",
+        "formatted_address": "4715 Blue Heron Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -15104,21 +12868,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2412",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/22",
-          "year": "2022",
-          "Address": "W 3224 29TH, Anchorage, Alaska",
-          "Parcel": "1004209000",
-          "Units": "0",
-          "Legal": "TURNAGAIN SOUTH BLK   2 LT  6  G:1626",
-          "Valuation": "15872",
-          "formatted_address": "3224 W 29th Ave, Anchorage, AK 99517, USA",
-          "lat": "61.1940494",
-          "lng": "-149.9440789"
-        }
+        "Permit": "R22-2412",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/22",
+        "year": "2022",
+        "Address": "W 3224 29TH, Anchorage, Alaska",
+        "Parcel": "1004209000",
+        "Units": "0",
+        "Legal": "TURNAGAIN SOUTH BLK   2 LT  6  G:1626",
+        "Valuation": "15872",
+        "formatted_address": "3224 W 29th Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -15131,21 +12891,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2457",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/22",
-          "year": "2022",
-          "Address": "6242 GREEN TREE, Anchorage, Alaska",
-          "Parcel": "1534153000",
-          "Units": "0",
-          "Legal": "VALLI VUE ESTATES #2 BLK   4 LT 10  G:2538",
-          "Valuation": "26000",
-          "formatted_address": "6242 Green Tree Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1283809",
-          "lng": "-149.7654477"
-        }
+        "Permit": "R22-2457",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/22",
+        "year": "2022",
+        "Address": "6242 GREEN TREE, Anchorage, Alaska",
+        "Parcel": "1534153000",
+        "Units": "0",
+        "Legal": "VALLI VUE ESTATES #2 BLK   4 LT 10  G:2538",
+        "Valuation": "26000",
+        "formatted_address": "6242 Green Tree Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -15158,21 +12914,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2463",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "8/31/22",
-          "year": "2022",
-          "Address": "7900 DOWNHILL CIRCLE, Anchorage, Alaska",
-          "Parcel": "1509213000",
-          "Units": "0",
-          "Legal": "PROSPECT HEIGHTS #1 BLK   6 LT  3  G:2440",
-          "Valuation": "25369",
-          "formatted_address": "7900 Downhill Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1334752",
-          "lng": "-149.7343947"
-        }
+        "Permit": "R22-2463",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "8/31/22",
+        "year": "2022",
+        "Address": "7900 DOWNHILL CIRCLE, Anchorage, Alaska",
+        "Parcel": "1509213000",
+        "Units": "0",
+        "Legal": "PROSPECT HEIGHTS #1 BLK   6 LT  3  G:2440",
+        "Valuation": "25369",
+        "formatted_address": "7900 Downhill Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -15185,21 +12937,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2465",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/22",
-          "year": "2022",
-          "Address": "3106 PLEASANT DRIVE, Anchorage, Alaska",
-          "Parcel": "1225109000",
-          "Units": "0",
-          "Legal": "SHADY BIRCH BLK   2 LT  1A  G:2226",
-          "Valuation": "23000",
-          "formatted_address": "3106 Pleasant Dr, Anchorage, AK 99502, USA",
-          "lat": "61.1461497",
-          "lng": "-149.9372981"
-        }
+        "Permit": "R22-2465",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/22",
+        "year": "2022",
+        "Address": "3106 PLEASANT DRIVE, Anchorage, Alaska",
+        "Parcel": "1225109000",
+        "Units": "0",
+        "Legal": "SHADY BIRCH BLK   2 LT  1A  G:2226",
+        "Valuation": "23000",
+        "formatted_address": "3106 Pleasant Dr, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -15212,21 +12960,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2533",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "E 3255 150TH, Anchorage, Alaska",
-          "Parcel": "1829212000",
-          "Units": "0",
-          "Legal": "T12N R3W SEC 33 LT 152  G:3134",
-          "Valuation": "41062",
-          "formatted_address": "3255 E 150th Ave, Anchorage, AK 99516, USA",
-          "lat": "61.0854509",
-          "lng": "-149.8217089"
-        }
+        "Permit": "R22-2533",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "E 3255 150TH, Anchorage, Alaska",
+        "Parcel": "1829212000",
+        "Units": "0",
+        "Legal": "T12N R3W SEC 33 LT 152  G:3134",
+        "Valuation": "41062",
+        "formatted_address": "3255 E 150th Ave, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -15239,21 +12983,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2534",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "3734 MOUNT BLANC, Anchorage, Alaska",
-          "Parcel": "324517000",
-          "Units": "0",
-          "Legal": "GENEVA WOODS BLK   2 LT 10  G:1732",
-          "Valuation": "27291",
-          "formatted_address": "3734 Mt Blanc Cir, Anchorage, AK 99508, USA",
-          "lat": "61.18692540000001",
-          "lng": "-149.8549423"
-        }
+        "Permit": "R22-2534",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "3734 MOUNT BLANC, Anchorage, Alaska",
+        "Parcel": "324517000",
+        "Units": "0",
+        "Legal": "GENEVA WOODS BLK   2 LT 10  G:1732",
+        "Valuation": "27291",
+        "formatted_address": "3734 Mt Blanc Cir, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -15266,21 +13006,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2537",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "8430 BARNETT DRIVE, Anchorage, Alaska",
-          "Parcel": "1221378000",
-          "Units": "0",
-          "Legal": "CASCADE HEIGHTS LT   6  G:2229",
-          "Valuation": "17000",
-          "formatted_address": "8430 Barnett Dr, Anchorage, AK 99518, USA",
-          "lat": "61.1447835",
-          "lng": "-149.9066279"
-        }
+        "Permit": "R22-2537",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "8430 BARNETT DRIVE, Anchorage, Alaska",
+        "Parcel": "1221378000",
+        "Units": "0",
+        "Legal": "CASCADE HEIGHTS LT   6  G:2229",
+        "Valuation": "17000",
+        "formatted_address": "8430 Barnett Dr, Anchorage, AK 99518, USA"
       }
     },
     {
@@ -15293,21 +13029,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2538",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "7631 GRIFFITH STREET, Anchorage, Alaska",
-          "Parcel": "1509259000",
-          "Units": "0",
-          "Legal": "PANORAMA TERRACE BLK   2 LT  9  G:2440",
-          "Valuation": "6000",
-          "formatted_address": "7631 Griffith St, Anchorage, AK 99507, USA",
-          "lat": "61.134003",
-          "lng": "-149.7416429"
-        }
+        "Permit": "R22-2538",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "7631 GRIFFITH STREET, Anchorage, Alaska",
+        "Parcel": "1509259000",
+        "Units": "0",
+        "Legal": "PANORAMA TERRACE BLK   2 LT  9  G:2440",
+        "Valuation": "6000",
+        "formatted_address": "7631 Griffith St, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -15320,21 +13052,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2565",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "1305 ATKINSON, Anchorage, Alaska",
-          "Parcel": "616748000",
-          "Units": "0",
-          "Legal": "NUNAKA VALLEY BLK   C LT  7  G:1438",
-          "Valuation": "15527",
-          "formatted_address": "1305 Atkinson Dr, Anchorage, AK 99504, USA",
-          "lat": "61.20917959999999",
-          "lng": "-149.7666576"
-        }
+        "Permit": "R22-2565",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "1305 ATKINSON, Anchorage, Alaska",
+        "Parcel": "616748000",
+        "Units": "0",
+        "Legal": "NUNAKA VALLEY BLK   C LT  7  G:1438",
+        "Valuation": "15527",
+        "formatted_address": "1305 Atkinson Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -15347,21 +13075,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2593",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "5085 HERITAGE HEIGHTS, Anchorage, Alaska",
-          "Parcel": "1522147000",
-          "Units": "0",
-          "Legal": "CROSS VIEWESTATES BLK   1 LT  4  G:2737",
-          "Valuation": "54000",
-          "formatted_address": "5085 Heritage Heights Dr, Anchorage, AK 99516, USA",
-          "lat": "61.1112155",
-          "lng": "-149.7883168"
-        }
+        "Permit": "R22-2593",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "5085 HERITAGE HEIGHTS, Anchorage, Alaska",
+        "Parcel": "1522147000",
+        "Units": "0",
+        "Legal": "CROSS VIEWESTATES BLK   1 LT  4  G:2737",
+        "Valuation": "54000",
+        "formatted_address": "5085 Heritage Heights Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -15374,21 +13098,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2595",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "1982 BRANDILYN, Anchorage, Alaska",
-          "Parcel": "1617404000",
-          "Units": "0",
-          "Legal": "BROOKWOOD NORTH BLK   1 LT  7  G:2733",
-          "Valuation": "32500",
-          "formatted_address": "1982 Brandilyn St, Anchorage, AK 99516, USA",
-          "lat": "61.1123661",
-          "lng": "-149.8457137"
-        }
+        "Permit": "R22-2595",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "1982 BRANDILYN, Anchorage, Alaska",
+        "Parcel": "1617404000",
+        "Units": "0",
+        "Legal": "BROOKWOOD NORTH BLK   1 LT  7  G:2733",
+        "Valuation": "32500",
+        "formatted_address": "1982 Brandilyn St, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -15401,21 +13121,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2597",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "4699 BLUE HERON CIRCLE, Anchorage, Alaska",
-          "Parcel": "1504459000",
-          "Units": "0",
-          "Legal": "SAHALEE PH4 BLK   1 LT 30  G:2336",
-          "Valuation": "25511",
-          "formatted_address": "4699 Blue Heron Cir, Anchorage, AK 99507, USA",
-          "lat": "61.138427",
-          "lng": "-149.7956019"
-        }
+        "Permit": "R22-2597",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "4699 BLUE HERON CIRCLE, Anchorage, Alaska",
+        "Parcel": "1504459000",
+        "Units": "0",
+        "Legal": "SAHALEE PH4 BLK   1 LT 30  G:2336",
+        "Valuation": "25511",
+        "formatted_address": "4699 Blue Heron Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -15428,21 +13144,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2667",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "5810 MILEY, Anchorage, Alaska",
-          "Parcel": "616325000",
-          "Units": "0",
-          "Legal": "NUNAKA VALLEY BLK   Q LT  6  G:1438",
-          "Valuation": "13792",
-          "formatted_address": "5810 Miley Dr, Anchorage, AK 99504, USA",
-          "lat": "61.2070031",
-          "lng": "-149.7725683"
-        }
+        "Permit": "R22-2667",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "5810 MILEY, Anchorage, Alaska",
+        "Parcel": "616325000",
+        "Units": "0",
+        "Legal": "NUNAKA VALLEY BLK   Q LT  6  G:1438",
+        "Valuation": "13792",
+        "formatted_address": "5810 Miley Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -15455,21 +13167,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2668",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "8001 WHITE DRIVE, Anchorage, Alaska",
-          "Parcel": "1509343000",
-          "Units": "0",
-          "Legal": "CONIFER HEIGHTS BLK   1 LT  7  G:2440",
-          "Valuation": "26280",
-          "formatted_address": "8001 White Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1362805",
-          "lng": "-149.7320765"
-        }
+        "Permit": "R22-2668",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "8001 WHITE DRIVE, Anchorage, Alaska",
+        "Parcel": "1509343000",
+        "Units": "0",
+        "Legal": "CONIFER HEIGHTS BLK   1 LT  7  G:2440",
+        "Valuation": "26280",
+        "formatted_address": "8001 White Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -15482,21 +13190,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2669",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "14100 JARVI, Anchorage, Alaska",
-          "Parcel": "1820430000",
-          "Units": "0",
-          "Legal": "SUNSET HILLS WEST BLK   3 LT 17B  G:3032",
-          "Valuation": "15340",
-          "formatted_address": "14100 Jarvi Dr, Anchorage, AK 99515, USA",
-          "lat": "61.0932917",
-          "lng": "-149.8501594"
-        }
+        "Permit": "R22-2669",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "14100 JARVI, Anchorage, Alaska",
+        "Parcel": "1820430000",
+        "Units": "0",
+        "Legal": "SUNSET HILLS WEST BLK   3 LT 17B  G:3032",
+        "Valuation": "15340",
+        "formatted_address": "14100 Jarvi Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -15509,21 +13213,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2670",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "6140 AZALEA DRIVE, Anchorage, Alaska",
-          "Parcel": "1712140000",
-          "Units": "0",
-          "Legal": "SEA TURN BLK   2 LT 16  G:3138",
-          "Valuation": "11204",
-          "formatted_address": "6140 Azalea Dr, Anchorage, AK 99516, USA",
-          "lat": "61.0840735",
-          "lng": "-149.7672101"
-        }
+        "Permit": "R22-2670",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "6140 AZALEA DRIVE, Anchorage, Alaska",
+        "Parcel": "1712140000",
+        "Units": "0",
+        "Legal": "SEA TURN BLK   2 LT 16  G:3138",
+        "Valuation": "11204",
+        "formatted_address": "6140 Azalea Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -15536,21 +13236,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2671",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "4125 PTARMIGAN TERRACE, Anchorage, Alaska",
-          "Parcel": "1833214000",
-          "Units": "0",
-          "Legal": "T12N R3W SEC 33 LT 251  G:3135",
-          "Valuation": "34960",
-          "formatted_address": "4125 Ptarmigan Terrace, Anchorage, AK 99516, USA",
-          "lat": "61.0802661",
-          "lng": "-149.8046901"
-        }
+        "Permit": "R22-2671",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "4125 PTARMIGAN TERRACE, Anchorage, Alaska",
+        "Parcel": "1833214000",
+        "Units": "0",
+        "Legal": "T12N R3W SEC 33 LT 251  G:3135",
+        "Valuation": "34960",
+        "formatted_address": "4125 Ptarmigan Terrace, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -15563,21 +13259,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2672",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/22",
-          "year": "2022",
-          "Address": "W 1112 15TH, Anchorage, Alaska",
-          "Parcel": "109410000",
-          "Units": "0",
-          "Legal": "SOUTH ADDITION BLK  44B LT4  G:1429",
-          "Valuation": "21064",
-          "formatted_address": "1112 E 15th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.2073195",
-          "lng": "-149.8626068"
-        }
+        "Permit": "R22-2672",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/22",
+        "year": "2022",
+        "Address": "W 1112 15TH, Anchorage, Alaska",
+        "Parcel": "109410000",
+        "Units": "0",
+        "Legal": "SOUTH ADDITION BLK  44B LT4  G:1429",
+        "Valuation": "21064",
+        "formatted_address": "1112 E 15th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -15590,21 +13282,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2708",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "10/31/22",
-          "year": "2022",
-          "Address": "2925 KIMBERLIE, Anchorage, Alaska",
-          "Parcel": "803146000",
-          "Units": "0",
-          "Legal": "PAUL W SMITH LT   3  G:1734",
-          "Valuation": "32968",
-          "formatted_address": "2925 Kimberlie Ct, Anchorage, AK 99508, USA",
-          "lat": "61.18420329999999",
-          "lng": "-149.8260714"
-        }
+        "Permit": "R22-2708",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "10/31/22",
+        "year": "2022",
+        "Address": "2925 KIMBERLIE, Anchorage, Alaska",
+        "Parcel": "803146000",
+        "Units": "0",
+        "Legal": "PAUL W SMITH LT   3  G:1734",
+        "Valuation": "32968",
+        "formatted_address": "2925 Kimberlie Ct, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -15617,21 +13305,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2717",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "10/31/22",
-          "year": "2022",
-          "Address": "5834 SAPPHIRE LOOP, Anchorage, Alaska",
-          "Parcel": "624502088",
-          "Units": "0",
-          "Legal": "SUMMER STONE LOT 1 SUMMER STONE TOWNHOMES G:1538",
-          "Valuation": "18759.02",
-          "formatted_address": "5834 Sapphire Loop, Anchorage, AK 99504, USA",
-          "lat": "61.2000943",
-          "lng": "-149.7756887"
-        }
+        "Permit": "R22-2717",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "10/31/22",
+        "year": "2022",
+        "Address": "5834 SAPPHIRE LOOP, Anchorage, Alaska",
+        "Parcel": "624502088",
+        "Units": "0",
+        "Legal": "SUMMER STONE LOT 1 SUMMER STONE TOWNHOMES G:1538",
+        "Valuation": "18759.02",
+        "formatted_address": "5834 Sapphire Loop, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -15644,21 +13328,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2743",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "10/31/22",
-          "year": "2022",
-          "Address": "11650 SUNCREST, Anchorage, Alaska",
-          "Parcel": "1911355000",
-          "Units": "0",
-          "Legal": "SUNCREST #1 LT  10  G:2728",
-          "Valuation": "21000",
-          "formatted_address": "11650 Suncrest Cir, Anchorage, AK 99515, USA",
-          "lat": "61.1156065",
-          "lng": "-149.915293"
-        }
+        "Permit": "R22-2743",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "10/31/22",
+        "year": "2022",
+        "Address": "11650 SUNCREST, Anchorage, Alaska",
+        "Parcel": "1911355000",
+        "Units": "0",
+        "Legal": "SUNCREST #1 LT  10  G:2728",
+        "Valuation": "21000",
+        "formatted_address": "11650 Suncrest Cir, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -15671,21 +13351,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2750",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "10/31/22",
-          "year": "2022",
-          "Address": "8206 SKYHILLS, Anchorage, Alaska",
-          "Parcel": "1112218000",
-          "Units": "0",
-          "Legal": "SKYHILLS PH 1 BLK   1 LT  7  G:2222",
-          "Valuation": "26607",
-          "formatted_address": "8206 Skyhills Dr, Anchorage, AK 99502, USA",
-          "lat": "61.1466964",
-          "lng": "-150.0065881"
-        }
+        "Permit": "R22-2750",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "10/31/22",
+        "year": "2022",
+        "Address": "8206 SKYHILLS, Anchorage, Alaska",
+        "Parcel": "1112218000",
+        "Units": "0",
+        "Legal": "SKYHILLS PH 1 BLK   1 LT  7  G:2222",
+        "Valuation": "26607",
+        "formatted_address": "8206 Skyhills Dr, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -15698,21 +13374,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R22-2757",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "10/31/22",
-          "year": "2022",
-          "Address": "1830 EVANGELINE LANE, Anchorage, Alaska",
-          "Parcel": "113119022",
-          "Units": "0",
-          "Legal": "ATWOOD ESTATES TR   A-1 ATWOOD ESTATES G:1427",
-          "Valuation": "27000",
-          "formatted_address": "1830 Evangeline Lane, Anchorage, AK 99517, USA",
-          "lat": "61.2035168",
-          "lng": "-149.930892"
-        }
+        "Permit": "R22-2757",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "10/31/22",
+        "year": "2022",
+        "Address": "1830 EVANGELINE LANE, Anchorage, Alaska",
+        "Parcel": "113119022",
+        "Units": "0",
+        "Legal": "ATWOOD ESTATES TR   A-1 ATWOOD ESTATES G:1427",
+        "Valuation": "27000",
+        "formatted_address": "1830 Evangeline Lane, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -15725,21 +13397,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C22-2181",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "12/31/22",
-          "year": "2022",
-          "Address": "E 2000 DOWLING, Anchorage, Alaska",
-          "Parcel": "1402113007",
-          "Units": "NA",
-          "Legal": "DOWLING LT  45 2000 DOWLING PLAZA G:2033",
-          "Valuation": "35000",
-          "formatted_address": "2000 E Dowling Rd, Anchorage, AK 99507, USA",
-          "lat": "61.16541710000001",
-          "lng": "-149.8454605"
-        }
+        "Permit": "C22-2181",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "12/31/22",
+        "year": "2022",
+        "Address": "E 2000 DOWLING, Anchorage, Alaska",
+        "Parcel": "1402113007",
+        "Units": "NA",
+        "Legal": "DOWLING LT  45 2000 DOWLING PLAZA G:2033",
+        "Valuation": "35000",
+        "formatted_address": "2000 E Dowling Rd, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -15752,21 +13420,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C23-1008",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "1/31/23",
-          "year": "2023",
-          "Address": "3510 SPENARD, Anchorage, Alaska",
-          "Parcel": "1010345000",
-          "Units": "NA",
-          "Legal": "SPENARDIA LT   2  G:1629",
-          "Valuation": "91800",
-          "formatted_address": "3510 Spenard Rd, Anchorage, AK 99503, USA",
-          "lat": "61.1883198",
-          "lng": "-149.9099353"
-        }
+        "Permit": "C23-1008",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "1/31/23",
+        "year": "2023",
+        "Address": "3510 SPENARD, Anchorage, Alaska",
+        "Parcel": "1010345000",
+        "Units": "NA",
+        "Legal": "SPENARDIA LT   2  G:1629",
+        "Valuation": "91800",
+        "formatted_address": "3510 Spenard Rd, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -15779,21 +13443,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1103",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2/28/23",
-          "year": "2023",
-          "Address": "1830 REBEL RIDGE, Anchorage, Alaska",
-          "Parcel": "620408000",
-          "Units": "1",
-          "Legal": "FOOTHILLS EAST BLK   1 LT  8  G:1441",
-          "Valuation": "16800",
-          "formatted_address": "1830 Rebel Ridge Dr, Anchorage, AK 99504, USA",
-          "lat": "61.2043534",
-          "lng": "-149.7241155"
-        }
+        "Permit": "R23-1103",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2/28/23",
+        "year": "2023",
+        "Address": "1830 REBEL RIDGE, Anchorage, Alaska",
+        "Parcel": "620408000",
+        "Units": "1",
+        "Legal": "FOOTHILLS EAST BLK   1 LT  8  G:1441",
+        "Valuation": "16800",
+        "formatted_address": "1830 Rebel Ridge Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -15806,21 +13466,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1104",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "2/28/23",
-          "year": "2023",
-          "Address": "6831 JOSEPH STREET, Anchorage, Alaska",
-          "Parcel": "1211230000",
-          "Units": "1",
-          "Legal": "BARNAN #2 BLK   1 LT 27  G:2129",
-          "Valuation": "25185",
-          "formatted_address": "6831 Joseph St, Anchorage, AK 99518, USA",
-          "lat": "61.1582707",
-          "lng": "-149.9006377"
-        }
+        "Permit": "R23-1104",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "2/28/23",
+        "year": "2023",
+        "Address": "6831 JOSEPH STREET, Anchorage, Alaska",
+        "Parcel": "1211230000",
+        "Units": "1",
+        "Legal": "BARNAN #2 BLK   1 LT 27  G:2129",
+        "Valuation": "25185",
+        "formatted_address": "6831 Joseph St, Anchorage, AK 99518, USA"
       }
     },
     {
@@ -15833,21 +13489,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1142",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/23",
-          "year": "2023",
-          "Address": "3918 WESLEYAN, Anchorage, Alaska",
-          "Parcel": "515213000",
-          "Units": "1",
-          "Legal": "CASTLE HEIGHTS BLK   1 LT 13  G:1737",
-          "Valuation": "16320",
-          "formatted_address": "3918 Wesleyan Dr, Anchorage, AK 99508, USA",
-          "lat": "61.18556450000001",
-          "lng": "-149.7928078"
-        }
+        "Permit": "R23-1142",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/23",
+        "year": "2023",
+        "Address": "3918 WESLEYAN, Anchorage, Alaska",
+        "Parcel": "515213000",
+        "Units": "1",
+        "Legal": "CASTLE HEIGHTS BLK   1 LT 13  G:1737",
+        "Valuation": "16320",
+        "formatted_address": "3918 Wesleyan Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -15860,21 +13512,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1143",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/23",
-          "year": "2023",
-          "Address": "16920 TIDEVIEW, Anchorage, Alaska",
-          "Parcel": "2009148000",
-          "Units": "1",
-          "Legal": "THE VILLAGES TIDE VIEW LT   4  G:3336",
-          "Valuation": "20276",
-          "formatted_address": "16920 Tideview Dr, Anchorage, AK 99516, USA",
-          "lat": "61.06729879999999",
-          "lng": "-149.7990711"
-        }
+        "Permit": "R23-1143",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/23",
+        "year": "2023",
+        "Address": "16920 TIDEVIEW, Anchorage, Alaska",
+        "Parcel": "2009148000",
+        "Units": "1",
+        "Legal": "THE VILLAGES TIDE VIEW LT   4  G:3336",
+        "Valuation": "20276",
+        "formatted_address": "16920 Tideview Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -15887,21 +13535,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1144",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/23",
-          "year": "2023",
-          "Address": "8650 BARNEY CIRCLE, Anchorage, Alaska",
-          "Parcel": "1425253000",
-          "Units": "1",
-          "Legal": "YOUNG MEADOWS LT   7  G:2334",
-          "Valuation": "15511",
-          "formatted_address": "8650 Barney Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1422454",
-          "lng": "-149.8297743"
-        }
+        "Permit": "R23-1144",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/23",
+        "year": "2023",
+        "Address": "8650 BARNEY CIRCLE, Anchorage, Alaska",
+        "Parcel": "1425253000",
+        "Units": "1",
+        "Legal": "YOUNG MEADOWS LT   7  G:2334",
+        "Valuation": "15511",
+        "formatted_address": "8650 Barney Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -15914,21 +13558,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1145",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/23",
-          "year": "2023",
-          "Address": "7020 FOOTHILL, Anchorage, Alaska",
-          "Parcel": "622318000",
-          "Units": "1",
-          "Legal": "INDIAN HILLS #3 BLK   5 LT 31  G:1439",
-          "Valuation": "14247",
-          "formatted_address": "7020 Foothill Dr, Anchorage, AK 99504, USA",
-          "lat": "61.2045165",
-          "lng": "-149.7507814"
-        }
+        "Permit": "R23-1145",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/23",
+        "year": "2023",
+        "Address": "7020 FOOTHILL, Anchorage, Alaska",
+        "Parcel": "622318000",
+        "Units": "1",
+        "Legal": "INDIAN HILLS #3 BLK   5 LT 31  G:1439",
+        "Valuation": "14247",
+        "formatted_address": "7020 Foothill Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -15941,21 +13581,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1146",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/23",
-          "year": "2023",
-          "Address": "7841 PORT ORFORD, Anchorage, Alaska",
-          "Parcel": "1509326000",
-          "Units": "1",
-          "Legal": "CONIFER HEIGHTS BLK   2 LT 11  G:2440",
-          "Valuation": "27610",
-          "formatted_address": "7841 Port Orford Dr, Anchorage, AK 99507, USA",
-          "lat": "61.13575520000001",
-          "lng": "-149.7332161"
-        }
+        "Permit": "R23-1146",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/23",
+        "year": "2023",
+        "Address": "7841 PORT ORFORD, Anchorage, Alaska",
+        "Parcel": "1509326000",
+        "Units": "1",
+        "Legal": "CONIFER HEIGHTS BLK   2 LT 11  G:2440",
+        "Valuation": "27610",
+        "formatted_address": "7841 Port Orford Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -15968,21 +13604,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1147",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/23",
-          "year": "2023",
-          "Address": "15000 EVERGREEN RIDGE, Anchorage, Alaska",
-          "Parcel": "1711280000",
-          "Units": "1",
-          "Legal": "FOREST RIDGE BLK   1 LT  7  G:3137",
-          "Valuation": "37459",
-          "formatted_address": "15000 Evergreen Ridge St, Anchorage, AK 99516, USA",
-          "lat": "61.084993",
-          "lng": "-149.7823795"
-        }
+        "Permit": "R23-1147",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/23",
+        "year": "2023",
+        "Address": "15000 EVERGREEN RIDGE, Anchorage, Alaska",
+        "Parcel": "1711280000",
+        "Units": "1",
+        "Legal": "FOREST RIDGE BLK   1 LT  7  G:3137",
+        "Valuation": "37459",
+        "formatted_address": "15000 Evergreen Ridge St, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -15995,21 +13627,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1150",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/23",
-          "year": "2023",
-          "Address": "8673 DRY CREEK, Anchorage, Alaska",
-          "Parcel": "1129158083",
-          "Units": "1",
-          "Legal": "SONOMA GLEN AT WESTPARK TR   1F SONOMA GLEN PH 32 G:2323",
-          "Valuation": "19962",
-          "formatted_address": "8673 Dry Creek Loop, Anchorage, AK 99502, USA",
-          "lat": "61.1425131",
-          "lng": "-149.9876957"
-        }
+        "Permit": "R23-1150",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/23",
+        "year": "2023",
+        "Address": "8673 DRY CREEK, Anchorage, Alaska",
+        "Parcel": "1129158083",
+        "Units": "1",
+        "Legal": "SONOMA GLEN AT WESTPARK TR   1F SONOMA GLEN PH 32 G:2323",
+        "Valuation": "19962",
+        "formatted_address": "8673 Dry Creek Loop, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -16022,21 +13650,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1151",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/23",
-          "year": "2023",
-          "Address": "11641 WAGNER, Anchorage, Alaska",
-          "Parcel": "1528232000",
-          "Units": "1",
-          "Legal": "THOMAS L BOYLE BLK   1 LT  1B  G:2734",
-          "Valuation": "33908",
-          "formatted_address": "11641 Wagner St, Anchorage, AK 99516, USA",
-          "lat": "61.115269",
-          "lng": "-149.8214662"
-        }
+        "Permit": "R23-1151",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/23",
+        "year": "2023",
+        "Address": "11641 WAGNER, Anchorage, Alaska",
+        "Parcel": "1528232000",
+        "Units": "1",
+        "Legal": "THOMAS L BOYLE BLK   1 LT  1B  G:2734",
+        "Valuation": "33908",
+        "formatted_address": "11641 Wagner St, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -16049,21 +13673,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1152",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/23",
-          "year": "2023",
-          "Address": "1946 COMMODORE DRIVE, Anchorage, Alaska",
-          "Parcel": "1606433000",
-          "Units": "1",
-          "Legal": "COMMODORE PARK BLK   4 LT 22A-1  G:2533",
-          "Valuation": "22810",
-          "formatted_address": "1946 Commodore Dr, Anchorage, AK 99507, USA",
-          "lat": "61.12484180000001",
-          "lng": "-149.8440507"
-        }
+        "Permit": "R23-1152",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/23",
+        "year": "2023",
+        "Address": "1946 COMMODORE DRIVE, Anchorage, Alaska",
+        "Parcel": "1606433000",
+        "Units": "1",
+        "Legal": "COMMODORE PARK BLK   4 LT 22A-1  G:2533",
+        "Valuation": "22810",
+        "formatted_address": "1946 Commodore Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -16076,21 +13696,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1153",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "2/28/23",
-          "year": "2023",
-          "Address": "9071 CATHEDRAL PLACE, Anchorage, Alaska",
-          "Parcel": "1431175000",
-          "Units": "1",
-          "Legal": "SOUTH MOUNTAIN MEADOWS #1 BLK   5 LT  3  G:2335",
-          "Valuation": "22810",
-          "formatted_address": "9071 Cathedral Pl, Anchorage, AK 99507, USA",
-          "lat": "61.13845240000001",
-          "lng": "-149.8086074"
-        }
+        "Permit": "R23-1153",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "2/28/23",
+        "year": "2023",
+        "Address": "9071 CATHEDRAL PLACE, Anchorage, Alaska",
+        "Parcel": "1431175000",
+        "Units": "1",
+        "Legal": "SOUTH MOUNTAIN MEADOWS #1 BLK   5 LT  3  G:2335",
+        "Valuation": "22810",
+        "formatted_address": "9071 Cathedral Pl, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -16103,21 +13719,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1272",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/23",
-          "year": "2023",
-          "Address": "E 5531 112TH, Anchorage, Alaska",
-          "Parcel": "1552125000",
-          "Units": "1",
-          "Legal": "T12N R3W SEC 22 LT  30  G:2637",
-          "Valuation": "24709",
-          "formatted_address": "5531 E 112th Ave, Anchorage, AK 99516, USA",
-          "lat": "61.1202419",
-          "lng": "-149.7790429"
-        }
+        "Permit": "R23-1272",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/23",
+        "year": "2023",
+        "Address": "E 5531 112TH, Anchorage, Alaska",
+        "Parcel": "1552125000",
+        "Units": "1",
+        "Legal": "T12N R3W SEC 22 LT  30  G:2637",
+        "Valuation": "24709",
+        "formatted_address": "5531 E 112th Ave, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -16130,21 +13742,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1273",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/23",
-          "year": "2023",
-          "Address": "232 EAST 10TH AVENUE, Anchorage, Alaska",
-          "Parcel": "213614000",
-          "Units": "1",
-          "Legal": "THIRD ADDITION BLK  13 LT  3  G:1331",
-          "Valuation": "17146",
-          "formatted_address": "232 E 10th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.212374",
-          "lng": "-149.8800077"
-        }
+        "Permit": "R23-1273",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/23",
+        "year": "2023",
+        "Address": "232 EAST 10TH AVENUE, Anchorage, Alaska",
+        "Parcel": "213614000",
+        "Units": "1",
+        "Legal": "THIRD ADDITION BLK  13 LT  3  G:1331",
+        "Valuation": "17146",
+        "formatted_address": "232 E 10th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -16157,21 +13765,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1274",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/23",
-          "year": "2023",
-          "Address": "4110 TAZLINA, Anchorage, Alaska",
-          "Parcel": "121224000",
-          "Units": "1",
-          "Legal": "TAZLINA BLK   2 LT  3  G:1525",
-          "Valuation": "22780",
-          "formatted_address": "4110 Tazlina Ave, Anchorage, AK 99517, USA",
-          "lat": "61.19729770000001",
-          "lng": "-149.9618121"
-        }
+        "Permit": "R23-1274",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/23",
+        "year": "2023",
+        "Address": "4110 TAZLINA, Anchorage, Alaska",
+        "Parcel": "121224000",
+        "Units": "1",
+        "Legal": "TAZLINA BLK   2 LT  3  G:1525",
+        "Valuation": "22780",
+        "formatted_address": "4110 Tazlina Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -16184,21 +13788,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1275",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/23",
-          "year": "2023",
-          "Address": "11090 HIDEAWAY LAKE, Anchorage, Alaska",
-          "Parcel": "1547124000",
-          "Units": "1",
-          "Legal": "HIDEAWAY LAKE BLK   1 LT  7A  G:2640",
-          "Valuation": "25268",
-          "formatted_address": "11090 Hideaway Lake Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1210099",
-          "lng": "-149.7441372"
-        }
+        "Permit": "R23-1275",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/23",
+        "year": "2023",
+        "Address": "11090 HIDEAWAY LAKE, Anchorage, Alaska",
+        "Parcel": "1547124000",
+        "Units": "1",
+        "Legal": "HIDEAWAY LAKE BLK   1 LT  7A  G:2640",
+        "Valuation": "25268",
+        "formatted_address": "11090 Hideaway Lake Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -16211,21 +13811,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1276",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/23",
-          "year": "2023",
-          "Address": "W 1351 25TH, Anchorage, Alaska",
-          "Parcel": "125512000",
-          "Units": "1",
-          "Legal": "CLAYTON BLK   1 LT 12A  G:1529",
-          "Valuation": "13218",
-          "formatted_address": "1351 W 25th Ave, Anchorage, AK 99503, USA",
-          "lat": "61.19871669999999",
-          "lng": "-149.9097672"
-        }
+        "Permit": "R23-1276",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/23",
+        "year": "2023",
+        "Address": "W 1351 25TH, Anchorage, Alaska",
+        "Parcel": "125512000",
+        "Units": "1",
+        "Legal": "CLAYTON BLK   1 LT 12A  G:1529",
+        "Valuation": "13218",
+        "formatted_address": "1351 W 25th Ave, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -16238,21 +13834,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1278",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/23",
-          "year": "2023",
-          "Address": "2317 TURNAGAIN, Anchorage, Alaska",
-          "Parcel": "118427000",
-          "Units": "1",
-          "Legal": "TURNAGAIN HOMES BLK   L LT 27  G:1527",
-          "Valuation": "28336",
-          "formatted_address": "2317 Turnagain Pkwy, Anchorage, AK 99517, USA",
-          "lat": "61.1992449",
-          "lng": "-149.9428281"
-        }
+        "Permit": "R23-1278",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/23",
+        "year": "2023",
+        "Address": "2317 TURNAGAIN, Anchorage, Alaska",
+        "Parcel": "118427000",
+        "Units": "1",
+        "Legal": "TURNAGAIN HOMES BLK   L LT 27  G:1527",
+        "Valuation": "28336",
+        "formatted_address": "2317 Turnagain Pkwy, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -16265,21 +13857,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1279",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "3/31/23",
-          "year": "2023",
-          "Address": "14530 ECHO CANYON, Anchorage, Alaska",
-          "Parcel": "4208127000",
-          "Units": "1",
-          "Legal": "BEEDE BLK   1 LT  9  G:3043",
-          "Valuation": "26439",
-          "formatted_address": "14530 Echo Canyon Rd, Anchorage, AK 99516, USA",
-          "lat": "61.08929",
-          "lng": "-149.695169"
-        }
+        "Permit": "R23-1279",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "3/31/23",
+        "year": "2023",
+        "Address": "14530 ECHO CANYON, Anchorage, Alaska",
+        "Parcel": "4208127000",
+        "Units": "1",
+        "Legal": "BEEDE BLK   1 LT  9  G:3043",
+        "Valuation": "26439",
+        "formatted_address": "14530 Echo Canyon Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -16292,21 +13880,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1438",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "4/30/23",
-          "year": "2023",
-          "Address": "E 4041 66TH, Anchorage, Alaska",
-          "Parcel": "1407654000",
-          "Units": "1",
-          "Legal": "CAMPBELL HEIGHTS BLK   5 LT 30A  G:2035",
-          "Valuation": "18000",
-          "formatted_address": "4041 E 66th Ave, Anchorage, AK 99507, USA",
-          "lat": "61.1611828",
-          "lng": "-149.8067978"
-        }
+        "Permit": "R23-1438",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "4/30/23",
+        "year": "2023",
+        "Address": "E 4041 66TH, Anchorage, Alaska",
+        "Parcel": "1407654000",
+        "Units": "1",
+        "Legal": "CAMPBELL HEIGHTS BLK   5 LT 30A  G:2035",
+        "Valuation": "18000",
+        "formatted_address": "4041 E 66th Ave, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -16319,21 +13903,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1439",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "4/30/23",
-          "year": "2023",
-          "Address": "1902 ALEUTIAN, Anchorage, Alaska",
-          "Parcel": "414438000",
-          "Units": "1",
-          "Legal": "CITY VIEW #2 BLK   4 LT 26  G:1434",
-          "Valuation": "22383",
-          "formatted_address": "1902 Aleutian St, Anchorage, AK 99508, USA",
-          "lat": "61.203301",
-          "lng": "-149.832391"
-        }
+        "Permit": "R23-1439",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "4/30/23",
+        "year": "2023",
+        "Address": "1902 ALEUTIAN, Anchorage, Alaska",
+        "Parcel": "414438000",
+        "Units": "1",
+        "Legal": "CITY VIEW #2 BLK   4 LT 26  G:1434",
+        "Valuation": "22383",
+        "formatted_address": "1902 Aleutian St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -16346,21 +13926,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1557",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/23",
-          "year": "2023",
-          "Address": "5558 YUKON CHARLIE LOOP, Anchorage, Alaska",
-          "Parcel": "1131249000",
-          "Units": "1",
-          "Legal": "WESTPARK ADDN 5 BLK  10 LT  9  G:2223",
-          "Valuation": "29125",
-          "formatted_address": "5558 Yukon Charlie Loop, Anchorage, AK 99502, USA",
-          "lat": "61.1508164",
-          "lng": "-149.9864611"
-        }
+        "Permit": "R23-1557",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/23",
+        "year": "2023",
+        "Address": "5558 YUKON CHARLIE LOOP, Anchorage, Alaska",
+        "Parcel": "1131249000",
+        "Units": "1",
+        "Legal": "WESTPARK ADDN 5 BLK  10 LT  9  G:2223",
+        "Valuation": "29125",
+        "formatted_address": "5558 Yukon Charlie Loop, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -16373,21 +13949,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1623",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "5/31/23",
-          "year": "2023",
-          "Address": "2321 YORKTOWN, Anchorage, Alaska",
-          "Parcel": "1623459000",
-          "Units": "1",
-          "Legal": "INDEPENDENCE PARK BLK   6 LT 24  G:2533",
-          "Valuation": "19200",
-          "formatted_address": "2321 Yorktown Cir, Anchorage, AK 99507, USA",
-          "lat": "61.12969500000001",
-          "lng": "-149.8395814"
-        }
+        "Permit": "R23-1623",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "5/31/23",
+        "year": "2023",
+        "Address": "2321 YORKTOWN, Anchorage, Alaska",
+        "Parcel": "1623459000",
+        "Units": "1",
+        "Legal": "INDEPENDENCE PARK BLK   6 LT 24  G:2533",
+        "Valuation": "19200",
+        "formatted_address": "2321 Yorktown Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -16400,21 +13972,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1624",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "5/31/23",
-          "year": "2023",
-          "Address": "13905 MULLIGAN ROAD, Anchorage, Alaska",
-          "Parcel": "1809241000",
-          "Units": "1",
-          "Legal": "T12N R3W SEC 27 LT  61B  G:2936",
-          "Valuation": "29757",
-          "formatted_address": "13905 Mulligan Rd, Anchorage, AK 99516, USA",
-          "lat": "61.09485720000001",
-          "lng": "-149.7959388"
-        }
+        "Permit": "R23-1624",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "5/31/23",
+        "year": "2023",
+        "Address": "13905 MULLIGAN ROAD, Anchorage, Alaska",
+        "Parcel": "1809241000",
+        "Units": "1",
+        "Legal": "T12N R3W SEC 27 LT  61B  G:2936",
+        "Valuation": "29757",
+        "formatted_address": "13905 Mulligan Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -16427,21 +13995,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1699",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/23",
-          "year": "2023",
-          "Address": "6700 FERNHILL, Anchorage, Alaska",
-          "Parcel": "1709131000",
-          "Units": "1",
-          "Legal": "PRATOR BLK   8 LT  4  G:3039",
-          "Valuation": "10551",
-          "formatted_address": "6700 Fernhill Ave, Anchorage, AK 99516, USA",
-          "lat": "61.08857080000001",
-          "lng": "-149.7564925"
-        }
+        "Permit": "R23-1699",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/23",
+        "year": "2023",
+        "Address": "6700 FERNHILL, Anchorage, Alaska",
+        "Parcel": "1709131000",
+        "Units": "1",
+        "Legal": "PRATOR BLK   8 LT  4  G:3039",
+        "Valuation": "10551",
+        "formatted_address": "6700 Fernhill Ave, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -16454,21 +14018,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1701",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/23",
-          "year": "2023",
-          "Address": "4140 VISCOUNT CIRCLE, Anchorage, Alaska",
-          "Parcel": "1114216000",
-          "Units": "1",
-          "Legal": "BRENTWOOD VILLAGE LT  24  G:2225",
-          "Valuation": "26510",
-          "formatted_address": "4140 Viscount Cir, Anchorage, AK 99502, USA",
-          "lat": "61.14763409999999",
-          "lng": "-149.9571591"
-        }
+        "Permit": "R23-1701",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/23",
+        "year": "2023",
+        "Address": "4140 VISCOUNT CIRCLE, Anchorage, Alaska",
+        "Parcel": "1114216000",
+        "Units": "1",
+        "Legal": "BRENTWOOD VILLAGE LT  24  G:2225",
+        "Valuation": "26510",
+        "formatted_address": "4140 Viscount Cir, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -16481,21 +14041,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1702",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/23",
-          "year": "2023",
-          "Address": "1503 KEPNER, Anchorage, Alaska",
-          "Parcel": "616709000",
-          "Units": "1",
-          "Legal": "NUNAKA VALLEY BLK   B LT 37  G:1438",
-          "Valuation": "13664",
-          "formatted_address": "1503 Kepner Dr, Anchorage, AK 99504, USA",
-          "lat": "61.2073839",
-          "lng": "-149.765712"
-        }
+        "Permit": "R23-1702",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/23",
+        "year": "2023",
+        "Address": "1503 KEPNER, Anchorage, Alaska",
+        "Parcel": "616709000",
+        "Units": "1",
+        "Legal": "NUNAKA VALLEY BLK   B LT 37  G:1438",
+        "Valuation": "13664",
+        "formatted_address": "1503 Kepner Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -16508,21 +14064,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1703",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/23",
-          "year": "2023",
-          "Address": "8021 RESURRECTION, Anchorage, Alaska",
-          "Parcel": "723171000",
-          "Units": "1",
-          "Legal": "CHUGACH FOOTHILLS BLK   2 LT 21  G:1741",
-          "Valuation": "14168",
-          "formatted_address": "8021 Resurrection Dr, Anchorage, AK 99504, USA",
-          "lat": "61.18177739999999",
-          "lng": "-149.7313598"
-        }
+        "Permit": "R23-1703",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/23",
+        "year": "2023",
+        "Address": "8021 RESURRECTION, Anchorage, Alaska",
+        "Parcel": "723171000",
+        "Units": "1",
+        "Legal": "CHUGACH FOOTHILLS BLK   2 LT 21  G:1741",
+        "Valuation": "14168",
+        "formatted_address": "8021 Resurrection Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -16535,21 +14087,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1704",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/23",
-          "year": "2023",
-          "Address": "19850 VILLAGES SCENIC, Anchorage, Alaska",
-          "Parcel": "2031121000",
-          "Units": "1",
-          "Legal": "T11N R3W SEC 14 & 15 BOUND ON N. BY THE VILLAGES TR 18\nAND THE S. BY TR 20 G:3738",
-          "Valuation": "25918",
-          "formatted_address": "19850 Villages Scenic Pkwy, Anchorage, AK 99516, USA",
-          "lat": "61.04094",
-          "lng": "-149.7728506"
-        }
+        "Permit": "R23-1704",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/23",
+        "year": "2023",
+        "Address": "19850 VILLAGES SCENIC, Anchorage, Alaska",
+        "Parcel": "2031121000",
+        "Units": "1",
+        "Legal": "T11N R3W SEC 14 & 15 BOUND ON N. BY THE VILLAGES TR 18\nAND THE S. BY TR 20 G:3738",
+        "Valuation": "25918",
+        "formatted_address": "19850 Villages Scenic Pkwy, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -16562,21 +14110,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1705",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/23",
-          "year": "2023",
-          "Address": "E 3124 16TH, Anchorage, Alaska",
-          "Parcel": "413193000",
-          "Units": "1",
-          "Legal": "THUNDERBIRD TERRACE #1 BLK   1 LT  3  G:1435",
-          "Valuation": "23959",
-          "formatted_address": "3124 E 16th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.2058572",
-          "lng": "-149.821672"
-        }
+        "Permit": "R23-1705",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/23",
+        "year": "2023",
+        "Address": "E 3124 16TH, Anchorage, Alaska",
+        "Parcel": "413193000",
+        "Units": "1",
+        "Legal": "THUNDERBIRD TERRACE #1 BLK   1 LT  3  G:1435",
+        "Valuation": "23959",
+        "formatted_address": "3124 E 16th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -16589,21 +14133,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1706",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "5/31/23",
-          "year": "2023",
-          "Address": "1414 GARDEN STREET, Anchorage, Alaska",
-          "Parcel": "411322000",
-          "Units": "1",
-          "Legal": "SAXTON BLK   2 LT 11  G:1434",
-          "Valuation": "16181",
-          "formatted_address": "1414 Garden St, Anchorage, AK 99508, USA",
-          "lat": "61.20850709999999",
-          "lng": "-149.8256788"
-        }
+        "Permit": "R23-1706",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "5/31/23",
+        "year": "2023",
+        "Address": "1414 GARDEN STREET, Anchorage, Alaska",
+        "Parcel": "411322000",
+        "Units": "1",
+        "Legal": "SAXTON BLK   2 LT 11  G:1434",
+        "Valuation": "16181",
+        "formatted_address": "1414 Garden St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -16616,21 +14156,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1751",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/23",
-          "year": "2023",
-          "Address": "3850 BOEK CIRCLE, Anchorage, Alaska",
-          "Parcel": "1416140000",
-          "Units": "1",
-          "Legal": "BOEKS LT   6  G:2235",
-          "Valuation": "22644",
-          "formatted_address": "3850 Boek Cir, Anchorage, AK 99507, USA",
-          "lat": "61.1506264",
-          "lng": "-149.8101705"
-        }
+        "Permit": "R23-1751",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/23",
+        "year": "2023",
+        "Address": "3850 BOEK CIRCLE, Anchorage, Alaska",
+        "Parcel": "1416140000",
+        "Units": "1",
+        "Legal": "BOEKS LT   6  G:2235",
+        "Valuation": "22644",
+        "formatted_address": "3850 Boek Cir, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -16643,21 +14179,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1752",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/23",
-          "year": "2023",
-          "Address": "7701 BERRY CIRCLE, Anchorage, Alaska",
-          "Parcel": "1223223000",
-          "Units": "1",
-          "Legal": "OLYMPIC HEIGHTS LT   1D  G:2227",
-          "Valuation": "18751",
-          "formatted_address": "7701 Berry Cir, Anchorage, AK 99502, USA",
-          "lat": "61.1511466",
-          "lng": "-149.931797"
-        }
+        "Permit": "R23-1752",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/23",
+        "year": "2023",
+        "Address": "7701 BERRY CIRCLE, Anchorage, Alaska",
+        "Parcel": "1223223000",
+        "Units": "1",
+        "Legal": "OLYMPIC HEIGHTS LT   1D  G:2227",
+        "Valuation": "18751",
+        "formatted_address": "7701 Berry Cir, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -16670,21 +14202,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1753",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "5/31/23",
-          "year": "2023",
-          "Address": "11101 WILDWOOD, Anchorage, Alaska",
-          "Parcel": "1515127000",
-          "Units": "1",
-          "Legal": "SOUTH LAKEWOOD HILLS #1 BLK   6 LT  5  G:2638",
-          "Valuation": "28627",
-          "formatted_address": "11101 Wildwood Dr, Anchorage, AK 99516, USA",
-          "lat": "61.12007260000001",
-          "lng": "-149.7611086"
-        }
+        "Permit": "R23-1753",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "5/31/23",
+        "year": "2023",
+        "Address": "11101 WILDWOOD, Anchorage, Alaska",
+        "Parcel": "1515127000",
+        "Units": "1",
+        "Legal": "SOUTH LAKEWOOD HILLS #1 BLK   6 LT  5  G:2638",
+        "Valuation": "28627",
+        "formatted_address": "11101 Wildwood Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -16697,21 +14225,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1814",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "LONG SPRING SOLAR LLC",
-          "Date": "6/30/23",
-          "year": "2023",
-          "Address": "5300 DE ARMOUN, Anchorage, Alaska",
-          "Parcel": "1734127000",
-          "Units": "1",
-          "Legal": "HOKAMA HEIGHTS #1 LT   5  G:2937",
-          "Valuation": "25455",
-          "formatted_address": "5300 De Armoun Rd, Anchorage, AK 99516, USA",
-          "lat": "61.09838670000001",
-          "lng": "-149.7831735"
-        }
+        "Permit": "R23-1814",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "LONG SPRING SOLAR LLC",
+        "Date": "6/30/23",
+        "year": "2023",
+        "Address": "5300 DE ARMOUN, Anchorage, Alaska",
+        "Parcel": "1734127000",
+        "Units": "1",
+        "Legal": "HOKAMA HEIGHTS #1 LT   5  G:2937",
+        "Valuation": "25455",
+        "formatted_address": "5300 De Armoun Rd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -16724,21 +14248,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1866",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/23",
-          "year": "2023",
-          "Address": "7501 BEACON HILL, Anchorage, Alaska",
-          "Parcel": "1509258000",
-          "Units": "1",
-          "Legal": "BEACON HILL ESTATES LT   6  G:2440",
-          "Valuation": "26606",
-          "formatted_address": "2807 Arctic Blvd, Anchorage, AK 99503, USA",
-          "lat": "61.1946991",
-          "lng": "-149.8975307"
-        }
+        "Permit": "R23-1866",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/23",
+        "year": "2023",
+        "Address": "7501 BEACON HILL, Anchorage, Alaska",
+        "Parcel": "1509258000",
+        "Units": "1",
+        "Legal": "BEACON HILL ESTATES LT   6  G:2440",
+        "Valuation": "26606",
+        "formatted_address": "2807 Arctic Blvd, Anchorage, AK 99503, USA"
       }
     },
     {
@@ -16751,21 +14271,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1867",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "6/30/23",
-          "year": "2023",
-          "Address": "7777 OLD HILLSIDE, Anchorage, Alaska",
-          "Parcel": "1707210000",
-          "Units": "1",
-          "Legal": "SOUTH HILLS BLK   4 LT  1  G:2940",
-          "Valuation": "38982",
-          "formatted_address": "7777 Old Hillside Way, Anchorage, AK 99516, USA",
-          "lat": "61.09575339999999",
-          "lng": "-149.7375677"
-        }
+        "Permit": "R23-1867",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "6/30/23",
+        "year": "2023",
+        "Address": "7777 OLD HILLSIDE, Anchorage, Alaska",
+        "Parcel": "1707210000",
+        "Units": "1",
+        "Legal": "SOUTH HILLS BLK   4 LT  1  G:2940",
+        "Valuation": "38982",
+        "formatted_address": "7777 Old Hillside Way, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -16778,21 +14294,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1931",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/23",
-          "year": "2023",
-          "Address": "1801 TALKEETNA, Anchorage, Alaska",
-          "Parcel": "414556000",
-          "Units": "1",
-          "Legal": "CITY VIEW #2 BLK   2 LT  8  G:1434",
-          "Valuation": "15709",
-          "formatted_address": "1801 Talkeetna St, Anchorage, AK 99508, USA",
-          "lat": "61.204202",
-          "lng": "-149.8362726"
-        }
+        "Permit": "R23-1931",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/23",
+        "year": "2023",
+        "Address": "1801 TALKEETNA, Anchorage, Alaska",
+        "Parcel": "414556000",
+        "Units": "1",
+        "Legal": "CITY VIEW #2 BLK   2 LT  8  G:1434",
+        "Valuation": "15709",
+        "formatted_address": "1801 Talkeetna St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -16805,21 +14317,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1932",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/23",
-          "year": "2023",
-          "Address": "6525 MICHIGAN BLVD, Anchorage, Alaska",
-          "Parcel": "1515112000",
-          "Units": "1",
-          "Legal": "SOUTH LAKEWOOD HILLS #1 BLK   1 LT 12  G:2638",
-          "Valuation": "18732",
-          "formatted_address": "6525 Michigan Blvd, Anchorage, AK 99516, USA",
-          "lat": "61.12161519999999",
-          "lng": "-149.7604879"
-        }
+        "Permit": "R23-1932",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/23",
+        "year": "2023",
+        "Address": "6525 MICHIGAN BLVD, Anchorage, Alaska",
+        "Parcel": "1515112000",
+        "Units": "1",
+        "Legal": "SOUTH LAKEWOOD HILLS #1 BLK   1 LT 12  G:2638",
+        "Valuation": "18732",
+        "formatted_address": "6525 Michigan Blvd, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -16832,21 +14340,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1933",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/23",
-          "year": "2023",
-          "Address": "W 1002 15TH, Anchorage, Alaska",
-          "Parcel": "109312000",
-          "Units": "1",
-          "Legal": "MARTIN ANDWELCH (SOUTH ADD) BLK  43A LT1  G:1429",
-          "Valuation": "15441",
-          "formatted_address": "1002 E 15th Ave, Anchorage, AK 99501, USA",
-          "lat": "61.20744379999999",
-          "lng": "-149.8648384"
-        }
+        "Permit": "R23-1933",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/23",
+        "year": "2023",
+        "Address": "W 1002 15TH, Anchorage, Alaska",
+        "Parcel": "109312000",
+        "Units": "1",
+        "Legal": "MARTIN ANDWELCH (SOUTH ADD) BLK  43A LT1  G:1429",
+        "Valuation": "15441",
+        "formatted_address": "1002 E 15th Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -16859,21 +14363,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1934",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/23",
-          "year": "2023",
-          "Address": "1437 BIRCHWOOD, Anchorage, Alaska",
-          "Parcel": "411325000",
-          "Units": "1",
-          "Legal": "SAXTON BLK   2 LT  8  G:1434",
-          "Valuation": "10602",
-          "formatted_address": "1437 Birchwood St, Anchorage, AK 99508, USA",
-          "lat": "61.2081122",
-          "lng": "-149.8265339"
-        }
+        "Permit": "R23-1934",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/23",
+        "year": "2023",
+        "Address": "1437 BIRCHWOOD, Anchorage, Alaska",
+        "Parcel": "411325000",
+        "Units": "1",
+        "Legal": "SAXTON BLK   2 LT  8  G:1434",
+        "Valuation": "10602",
+        "formatted_address": "1437 Birchwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -16886,21 +14386,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1935",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/23",
-          "year": "2023",
-          "Address": "2662 LOVEJOY DRIVE, Anchorage, Alaska",
-          "Parcel": "416406000",
-          "Units": "1",
-          "Legal": "ANCHOR PARK BLK   4 LT  6  G:1534",
-          "Valuation": "8250",
-          "formatted_address": "2662 Lovejoy Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1963508",
-          "lng": "-149.8347221"
-        }
+        "Permit": "R23-1935",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/23",
+        "year": "2023",
+        "Address": "2662 LOVEJOY DRIVE, Anchorage, Alaska",
+        "Parcel": "416406000",
+        "Units": "1",
+        "Legal": "ANCHOR PARK BLK   4 LT  6  G:1534",
+        "Valuation": "8250",
+        "formatted_address": "2662 Lovejoy Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -16913,21 +14409,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1936",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/23",
-          "year": "2023",
-          "Address": "W 3442 82ND, Anchorage, Alaska",
-          "Parcel": "1225231000",
-          "Units": "1",
-          "Legal": "MCWILLIAMS BLK   1A LT8  G:2226",
-          "Valuation": "12808",
-          "formatted_address": "3442 W 82nd Ave, Anchorage, AK 99502, USA",
-          "lat": "61.146305",
-          "lng": "-149.9436952"
-        }
+        "Permit": "R23-1936",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/23",
+        "year": "2023",
+        "Address": "W 3442 82ND, Anchorage, Alaska",
+        "Parcel": "1225231000",
+        "Units": "1",
+        "Legal": "MCWILLIAMS BLK   1A LT8  G:2226",
+        "Valuation": "12808",
+        "formatted_address": "3442 W 82nd Ave, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -16940,21 +14432,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1937",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/23",
-          "year": "2023",
-          "Address": "2739 INGRA, Anchorage, Alaska",
-          "Parcel": "319714000",
-          "Units": "1",
-          "Legal": "LAMPERT #2 BLK   A LT 11  G:1532",
-          "Valuation": "19461",
-          "formatted_address": "2739 Ingra St, Anchorage, AK 99508, USA",
-          "lat": "61.1958463",
-          "lng": "-149.8656937"
-        }
+        "Permit": "R23-1937",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/23",
+        "year": "2023",
+        "Address": "2739 INGRA, Anchorage, Alaska",
+        "Parcel": "319714000",
+        "Units": "1",
+        "Legal": "LAMPERT #2 BLK   A LT 11  G:1532",
+        "Valuation": "19461",
+        "formatted_address": "2739 Ingra St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -16967,21 +14455,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1995",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/23",
-          "year": "2023",
-          "Address": "1825 ALDER, Anchorage, Alaska",
-          "Parcel": "414224000",
-          "Units": "1",
-          "Legal": "SAXTON BLK   7 LT  3  G:1434",
-          "Valuation": "9109",
-          "formatted_address": "1825 Alder Dr, Anchorage, AK 99508, USA",
-          "lat": "61.2037359",
-          "lng": "-149.8286217"
-        }
+        "Permit": "R23-1995",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/23",
+        "year": "2023",
+        "Address": "1825 ALDER, Anchorage, Alaska",
+        "Parcel": "414224000",
+        "Units": "1",
+        "Legal": "SAXTON BLK   7 LT  3  G:1434",
+        "Valuation": "9109",
+        "formatted_address": "1825 Alder Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -16994,21 +14478,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-1996",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "6/30/23",
-          "year": "2023",
-          "Address": "E 5200 98TH, Anchorage, Alaska",
-          "Parcel": "1507314000",
-          "Units": "1",
-          "Legal": "WILLIAMSON BLK   2 LT 11  G:2437",
-          "Valuation": "9109",
-          "formatted_address": "5200 E 98th Ave, Anchorage, AK 99507, USA",
-          "lat": "61.1304796",
-          "lng": "-149.7846043"
-        }
+        "Permit": "R23-1996",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "6/30/23",
+        "year": "2023",
+        "Address": "E 5200 98TH, Anchorage, Alaska",
+        "Parcel": "1507314000",
+        "Units": "1",
+        "Legal": "WILLIAMSON BLK   2 LT 11  G:2437",
+        "Valuation": "9109",
+        "formatted_address": "5200 E 98th Ave, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -17021,21 +14501,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2304",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/23",
-          "year": "2023",
-          "Address": "2622 LOVEJOY DRIVE, Anchorage, Alaska",
-          "Parcel": "416402000",
-          "Units": "1",
-          "Legal": "ANCHOR PARK BLK   4 LT  2  G:1534",
-          "Valuation": "4500",
-          "formatted_address": "2622 Lovejoy Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1970257",
-          "lng": "-149.8347515"
-        }
+        "Permit": "R23-2304",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/23",
+        "year": "2023",
+        "Address": "2622 LOVEJOY DRIVE, Anchorage, Alaska",
+        "Parcel": "416402000",
+        "Units": "1",
+        "Legal": "ANCHOR PARK BLK   4 LT  2  G:1534",
+        "Valuation": "4500",
+        "formatted_address": "2622 Lovejoy Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -17048,21 +14524,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2333",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/23",
-          "year": "2023",
-          "Address": "4841 RIDGE TOP, Anchorage, Alaska",
-          "Parcel": "631182000",
-          "Units": "1",
-          "Legal": "PINE RIDGE LT   2  G:1537",
-          "Valuation": "22000",
-          "formatted_address": "4841 Ridge Top Cir, Anchorage, AK 99508, USA",
-          "lat": "61.20225499999999",
-          "lng": "-149.7902166"
-        }
+        "Permit": "R23-2333",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/23",
+        "year": "2023",
+        "Address": "4841 RIDGE TOP, Anchorage, Alaska",
+        "Parcel": "631182000",
+        "Units": "1",
+        "Legal": "PINE RIDGE LT   2  G:1537",
+        "Valuation": "22000",
+        "formatted_address": "4841 Ridge Top Cir, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -17075,21 +14547,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2386",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/23",
-          "year": "2023",
-          "Address": "7733 REGAL MOUNTAIN, Anchorage, Alaska",
-          "Parcel": "712688000",
-          "Units": "1",
-          "Legal": "CHUGACH MOUNTAIN ESTATES BLK   1 LT 32  G:1740",
-          "Valuation": "14961",
-          "formatted_address": "7733 Regal Mountain Dr, Anchorage, AK 99504, USA",
-          "lat": "61.1828628",
-          "lng": "-149.7349304"
-        }
+        "Permit": "R23-2386",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/23",
+        "year": "2023",
+        "Address": "7733 REGAL MOUNTAIN, Anchorage, Alaska",
+        "Parcel": "712688000",
+        "Units": "1",
+        "Legal": "CHUGACH MOUNTAIN ESTATES BLK   1 LT 32  G:1740",
+        "Valuation": "14961",
+        "formatted_address": "7733 Regal Mountain Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -17102,21 +14570,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2387",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/23",
-          "year": "2023",
-          "Address": "4601 MARS, Anchorage, Alaska",
-          "Parcel": "1504235000",
-          "Units": "1",
-          "Legal": "ZODIAK MANOR ALASKA BLK   7 LT 12  G:2336",
-          "Valuation": "21155",
-          "formatted_address": "4601 Mars Dr, Anchorage, AK 99507, USA",
-          "lat": "61.13962040000001",
-          "lng": "-149.796683"
-        }
+        "Permit": "R23-2387",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/23",
+        "year": "2023",
+        "Address": "4601 MARS, Anchorage, Alaska",
+        "Parcel": "1504235000",
+        "Units": "1",
+        "Legal": "ZODIAK MANOR ALASKA BLK   7 LT 12  G:2336",
+        "Valuation": "21155",
+        "formatted_address": "4601 Mars Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -17129,21 +14593,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2388",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/23",
-          "year": "2023",
-          "Address": "W 2705 32ND, Anchorage, Alaska",
-          "Parcel": "1003636000",
-          "Units": "1",
-          "Legal": "WOODLAND PARK LT  14U & LT 15U W2  G:1627",
-          "Valuation": "13642",
-          "formatted_address": "2705 W 32nd Ave, Anchorage, AK 99517, USA",
-          "lat": "61.191881",
-          "lng": "-149.9346907"
-        }
+        "Permit": "R23-2388",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/23",
+        "year": "2023",
+        "Address": "W 2705 32ND, Anchorage, Alaska",
+        "Parcel": "1003636000",
+        "Units": "1",
+        "Legal": "WOODLAND PARK LT  14U & LT 15U W2  G:1627",
+        "Valuation": "13642",
+        "formatted_address": "2705 W 32nd Ave, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -17156,21 +14616,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2389",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/23",
-          "year": "2023",
-          "Address": "5915 MUIRWOOD, Anchorage, Alaska",
-          "Parcel": "1142315000",
-          "Units": "1",
-          "Legal": "MUIRWOOD PARK BLK   2 LT 10  G:2123",
-          "Valuation": "16264",
-          "formatted_address": "5915 Muirwood Dr, Anchorage, AK 99502, USA",
-          "lat": "61.15534659999999",
-          "lng": "-149.9891458"
-        }
+        "Permit": "R23-2389",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/23",
+        "year": "2023",
+        "Address": "5915 MUIRWOOD, Anchorage, Alaska",
+        "Parcel": "1142315000",
+        "Units": "1",
+        "Legal": "MUIRWOOD PARK BLK   2 LT 10  G:2123",
+        "Valuation": "16264",
+        "formatted_address": "5915 Muirwood Dr, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -17183,21 +14639,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2470",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/23",
-          "year": "2023",
-          "Address": "16300 SANDPIPER, Anchorage, Alaska",
-          "Parcel": "2004280000",
-          "Units": "1",
-          "Legal": "PTARMIGAN ROOST BLK   2 LT 12  G:3238",
-          "Valuation": "30559",
-          "formatted_address": "16300 Sandpiper Dr, Anchorage, AK 99516, USA",
-          "lat": "61.07455369999999",
-          "lng": "-149.7608855"
-        }
+        "Permit": "R23-2470",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/23",
+        "year": "2023",
+        "Address": "16300 SANDPIPER, Anchorage, Alaska",
+        "Parcel": "2004280000",
+        "Units": "1",
+        "Legal": "PTARMIGAN ROOST BLK   2 LT 12  G:3238",
+        "Valuation": "30559",
+        "formatted_address": "16300 Sandpiper Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -17210,21 +14662,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2471",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/23",
-          "year": "2023",
-          "Address": "E 2801 16TH, Anchorage, Alaska",
-          "Parcel": "411201000",
-          "Units": "1",
-          "Legal": "SAXTON BLK  10 LT  8  G:1434",
-          "Valuation": "23959",
-          "formatted_address": "2801 E 16th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.20629659999999",
-          "lng": "-149.8284631"
-        }
+        "Permit": "R23-2471",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/23",
+        "year": "2023",
+        "Address": "E 2801 16TH, Anchorage, Alaska",
+        "Parcel": "411201000",
+        "Units": "1",
+        "Legal": "SAXTON BLK  10 LT  8  G:1434",
+        "Valuation": "23959",
+        "formatted_address": "2801 E 16th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -17237,21 +14685,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2472",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/23",
-          "year": "2023",
-          "Address": "2055 CAMPBELL PLACE, Anchorage, Alaska",
-          "Parcel": "919533000",
-          "Units": "1",
-          "Legal": "WICKERSHAM PARK BLK   2 LT 56  G:1833",
-          "Valuation": "24939",
-          "formatted_address": "2055 Campbell Pl, Anchorage, AK 99507, USA",
-          "lat": "61.1753142",
-          "lng": "-149.8440135"
-        }
+        "Permit": "R23-2472",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/23",
+        "year": "2023",
+        "Address": "2055 CAMPBELL PLACE, Anchorage, Alaska",
+        "Parcel": "919533000",
+        "Units": "1",
+        "Legal": "WICKERSHAM PARK BLK   2 LT 56  G:1833",
+        "Valuation": "24939",
+        "formatted_address": "2055 Campbell Pl, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -17264,21 +14708,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2486",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "8/31/23",
-          "year": "2023",
-          "Address": "415 ATLANTIS AVENUE, Anchorage, Alaska",
-          "Parcel": "923246000",
-          "Units": "1",
-          "Legal": "INTERNATIONAL TOWNHOUSE BLK   3 LT  2  G:1930",
-          "Valuation": "12000",
-          "formatted_address": "415 Atlantis Ave, Anchorage, AK 99518, USA",
-          "lat": "61.17111749999999",
-          "lng": "-149.8899205"
-        }
+        "Permit": "R23-2486",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "8/31/23",
+        "year": "2023",
+        "Address": "415 ATLANTIS AVENUE, Anchorage, Alaska",
+        "Parcel": "923246000",
+        "Units": "1",
+        "Legal": "INTERNATIONAL TOWNHOUSE BLK   3 LT  2  G:1930",
+        "Valuation": "12000",
+        "formatted_address": "415 Atlantis Ave, Anchorage, AK 99518, USA"
       }
     },
     {
@@ -17291,21 +14731,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2492",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "8/31/23",
-          "year": "2023",
-          "Address": "4801 ZENITH STREET, Anchorage, Alaska",
-          "Parcel": "1501418000",
-          "Units": "1",
-          "Legal": "ZODIAK MANOR ALASKA BLK 13 LT 15  G:2336",
-          "Valuation": "16181",
-          "formatted_address": "4801 Zenith St, Anchorage, AK 99507, USA",
-          "lat": "61.14244349999999",
-          "lng": "-149.7943148"
-        }
+        "Permit": "R23-2492",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "8/31/23",
+        "year": "2023",
+        "Address": "4801 ZENITH STREET, Anchorage, Alaska",
+        "Parcel": "1501418000",
+        "Units": "1",
+        "Legal": "ZODIAK MANOR ALASKA BLK 13 LT 15  G:2336",
+        "Valuation": "16181",
+        "formatted_address": "4801 Zenith St, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -17318,21 +14754,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C23-1923",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "732 O, Anchorage, Alaska",
-          "Parcel": "105122000",
-          "Units": "NA",
-          "Legal": "ORIGINAL BLK 88 LT 5A G:1329",
-          "Valuation": "20546",
-          "formatted_address": "732 O St, Anchorage, AK 99501, USA",
-          "lat": "61.2149113",
-          "lng": "-149.9103977"
-        }
+        "Permit": "C23-1923",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "732 O, Anchorage, Alaska",
+        "Parcel": "105122000",
+        "Units": "NA",
+        "Legal": "ORIGINAL BLK 88 LT 5A G:1329",
+        "Valuation": "20546",
+        "formatted_address": "732 O St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -17345,21 +14777,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C23-1924",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "NA, Anchorage, Alaska",
-          "Parcel": "NA",
-          "Units": "NA",
-          "Legal": "NA",
-          "Valuation": "18295",
-          "formatted_address": "2452 E Tudor Rd, Anchorage, AK 99507, USA",
-          "lat": "61.1802492",
-          "lng": "-149.8356862"
-        }
+        "Permit": "C23-1924",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "NA, Anchorage, Alaska",
+        "Parcel": "NA",
+        "Units": "NA",
+        "Legal": "NA",
+        "Valuation": "18295",
+        "formatted_address": "2452 E Tudor Rd, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -17372,21 +14800,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "C23-1948",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "111 WEST SHIP CREEK AVENUE, Anchorage, Alaska",
-          "Parcel": "208651001",
-          "Units": "NA",
-          "Legal": "ARR 9655 SHIP CREEKCROSSING LT 1 & PTN OF TR A G:1231",
-          "Valuation": "454772",
-          "formatted_address": "111 W Ship Creek Ave, Anchorage, AK 99501, USA",
-          "lat": "61.22291579999999",
-          "lng": "-149.8837506"
-        }
+        "Permit": "C23-1948",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "111 WEST SHIP CREEK AVENUE, Anchorage, Alaska",
+        "Parcel": "208651001",
+        "Units": "NA",
+        "Legal": "ARR 9655 SHIP CREEKCROSSING LT 1 & PTN OF TR A G:1231",
+        "Valuation": "454772",
+        "formatted_address": "111 W Ship Creek Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -17399,21 +14823,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2610",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "13001 NORAK, Anchorage, Alaska",
-          "Parcel": "1736134000",
-          "Units": "1",
-          "Legal": "MCMAHON #2 BLK 5 LT 4 G:2835",
-          "Valuation": "18192",
-          "formatted_address": "13001 Norak Pl, Anchorage, AK 99516, USA",
-          "lat": "61.1031649",
-          "lng": "-149.804823"
-        }
+        "Permit": "R23-2610",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "13001 NORAK, Anchorage, Alaska",
+        "Parcel": "1736134000",
+        "Units": "1",
+        "Legal": "MCMAHON #2 BLK 5 LT 4 G:2835",
+        "Valuation": "18192",
+        "formatted_address": "13001 Norak Pl, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -17426,21 +14846,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2611",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "2346 LOUSSAC, Anchorage, Alaska",
-          "Parcel": "118315000",
-          "Units": "1",
-          "Legal": "TURNAGAIN HEIGHTS BLK D LT 9 G:1527",
-          "Valuation": "22997",
-          "formatted_address": "2346 Loussac Dr, Anchorage, AK 99517, USA",
-          "lat": "61.19926359999999",
-          "lng": "-149.936052"
-        }
+        "Permit": "R23-2611",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "2346 LOUSSAC, Anchorage, Alaska",
+        "Parcel": "118315000",
+        "Units": "1",
+        "Legal": "TURNAGAIN HEIGHTS BLK D LT 9 G:1527",
+        "Valuation": "22997",
+        "formatted_address": "2346 Loussac Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -17453,21 +14869,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2612",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "300 OCEANVIEW, Anchorage, Alaska",
-          "Parcel": "1806347000",
-          "Units": "1",
-          "Legal": "OCEANVIEW #4 BLK 6 LT 23 G:2831",
-          "Valuation": "31258",
-          "formatted_address": "300 Oceanview Dr, Anchorage, AK 99515, USA",
-          "lat": "61.10329909999999",
-          "lng": "-149.8778858"
-        }
+        "Permit": "R23-2612",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "300 OCEANVIEW, Anchorage, Alaska",
+        "Parcel": "1806347000",
+        "Units": "1",
+        "Legal": "OCEANVIEW #4 BLK 6 LT 23 G:2831",
+        "Valuation": "31258",
+        "formatted_address": "300 Oceanview Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -17480,21 +14892,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2613",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "2410 OAK DRIVE DRIVE, Anchorage, Alaska",
-          "Parcel": "415304000",
-          "Units": "1",
-          "Legal": "ANCHOR PARK BLK 7 LT 4 P-254 G:1534",
-          "Valuation": "7518",
-          "formatted_address": "2410 Oak Dr, Anchorage, AK 99508, USA",
-          "lat": "61.201452",
-          "lng": "-149.8364012"
-        }
+        "Permit": "R23-2613",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "2410 OAK DRIVE DRIVE, Anchorage, Alaska",
+        "Parcel": "415304000",
+        "Units": "1",
+        "Legal": "ANCHOR PARK BLK 7 LT 4 P-254 G:1534",
+        "Valuation": "7518",
+        "formatted_address": "2410 Oak Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -17507,21 +14915,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2624",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "8600 ROSALIND, Anchorage, Alaska",
-          "Parcel": "1425320000",
-          "Units": "1",
-          "Legal": "DORA #3 BLK 3 LT 20 G:2334",
-          "Valuation": "19880",
-          "formatted_address": "8600 Rosalind St, Anchorage, AK 99507, USA",
-          "lat": "61.14278040000001",
-          "lng": "-149.8227269"
-        }
+        "Permit": "R23-2624",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "8600 ROSALIND, Anchorage, Alaska",
+        "Parcel": "1425320000",
+        "Units": "1",
+        "Legal": "DORA #3 BLK 3 LT 20 G:2334",
+        "Valuation": "19880",
+        "formatted_address": "8600 Rosalind St, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -17534,21 +14938,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2625",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "2404 SAINT ELIAS, Anchorage, Alaska",
-          "Parcel": "123622000",
-          "Units": "1",
-          "Legal": "TURNAGAIN HOMES BLK H LT 9 G:1527",
-          "Valuation": "14935",
-          "formatted_address": "2404 St Elias Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1983239",
-          "lng": "-149.9418923"
-        }
+        "Permit": "R23-2625",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "2404 SAINT ELIAS, Anchorage, Alaska",
+        "Parcel": "123622000",
+        "Units": "1",
+        "Legal": "TURNAGAIN HOMES BLK H LT 9 G:1527",
+        "Valuation": "14935",
+        "formatted_address": "2404 St Elias Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -17561,21 +14961,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2658",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "8101 EAST 4TH AVENUE, Anchorage, Alaska",
-          "Parcel": "605417000",
-          "Units": "1",
-          "Legal": "NEVILLA PARK LT 61 G:1241",
-          "Valuation": "19622",
-          "formatted_address": "8101 E 4th Ave, Anchorage, AK 99504, USA",
-          "lat": "61.2190441",
-          "lng": "-149.7296782"
-        }
+        "Permit": "R23-2658",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "8101 EAST 4TH AVENUE, Anchorage, Alaska",
+        "Parcel": "605417000",
+        "Units": "1",
+        "Legal": "NEVILLA PARK LT 61 G:1241",
+        "Valuation": "19622",
+        "formatted_address": "8101 E 4th Ave, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -17588,21 +14984,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2659",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "7731 ISLAND, Anchorage, Alaska",
-          "Parcel": "621107000",
-          "Units": "1",
-          "Legal": "CHESTER VALLEY BLK 1 LT 7 G:1440",
-          "Valuation": "18999",
-          "formatted_address": "7731 Island Dr, Anchorage, AK 99504, USA",
-          "lat": "61.20546299999999",
-          "lng": "-149.73680770000001"
-        }
+        "Permit": "R23-2659",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "RENEWABLE ENERGY SYSTEMS",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "7731 ISLAND, Anchorage, Alaska",
+        "Parcel": "621107000",
+        "Units": "1",
+        "Legal": "CHESTER VALLEY BLK 1 LT 7 G:1440",
+        "Valuation": "18999",
+        "formatted_address": "7731 Island Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -17615,21 +15007,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2669",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "3140 ADMIRALTY BAY, Anchorage, Alaska",
-          "Parcel": "1247503000",
-          "Units": "1",
-          "Legal": "BAYSHORE WEST #4A BLK 4 LT 3 G:2526",
-          "Valuation": "13960",
-          "formatted_address": "3140 Admiralty Bay Dr, Anchorage, AK 99515, USA",
-          "lat": "61.1274693",
-          "lng": "-149.9385061"
-        }
+        "Permit": "R23-2669",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "3140 ADMIRALTY BAY, Anchorage, Alaska",
+        "Parcel": "1247503000",
+        "Units": "1",
+        "Legal": "BAYSHORE WEST #4A BLK 4 LT 3 G:2526",
+        "Valuation": "13960",
+        "formatted_address": "3140 Admiralty Bay Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -17642,21 +15030,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2767",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "12104 WOODCHASE, Anchorage, Alaska",
-          "Parcel": "1528406000",
-          "Units": "1",
-          "Legal": "DEVONSHIRE BLK 1 LT 6 G:2734",
-          "Valuation": "13270",
-          "formatted_address": "12104 Woodchase Dr, Anchorage, AK 99516, USA",
-          "lat": "61.11129510000001",
-          "lng": "-149.8301227"
-        }
+        "Permit": "R23-2767",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "12104 WOODCHASE, Anchorage, Alaska",
+        "Parcel": "1528406000",
+        "Units": "1",
+        "Legal": "DEVONSHIRE BLK 1 LT 6 G:2734",
+        "Valuation": "13270",
+        "formatted_address": "12104 Woodchase Dr, Anchorage, AK 99516, USA"
       }
     },
     {
@@ -17669,21 +15053,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2768",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "2626 COTTONWOOD, Anchorage, Alaska",
-          "Parcel": "319318000",
-          "Units": "1",
-          "Legal": "ROGERS PARK BLK 18 LT 4 G:1532",
-          "Valuation": "20080",
-          "formatted_address": "2626 Cottonwood St, Anchorage, AK 99508, USA",
-          "lat": "61.19664249999999",
-          "lng": "-149.8549654"
-        }
+        "Permit": "R23-2768",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "2626 COTTONWOOD, Anchorage, Alaska",
+        "Parcel": "319318000",
+        "Units": "1",
+        "Legal": "ROGERS PARK BLK 18 LT 4 G:1532",
+        "Valuation": "20080",
+        "formatted_address": "2626 Cottonwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -17696,21 +15076,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2769",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "6640 LAWLOR CIRCLE, Anchorage, Alaska",
-          "Parcel": "1102226000",
-          "Units": "1",
-          "Legal": "SEELEY ESTATES BLK 1 LT 9 G:2025",
-          "Valuation": "22364",
-          "formatted_address": "6640 Lawlor Cir, Anchorage, AK 99502, USA",
-          "lat": "61.1604083",
-          "lng": "-149.9612699"
-        }
+        "Permit": "R23-2769",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "6640 LAWLOR CIRCLE, Anchorage, Alaska",
+        "Parcel": "1102226000",
+        "Units": "1",
+        "Legal": "SEELEY ESTATES BLK 1 LT 9 G:2025",
+        "Valuation": "22364",
+        "formatted_address": "6640 Lawlor Cir, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -17723,21 +15099,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2770",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "2212 COUNTRY BROOK, Anchorage, Alaska",
-          "Parcel": "1252612000",
-          "Units": "1",
-          "Legal": "SILVERTREE BLK 2 LT 12 G:2228",
-          "Valuation": "22307",
-          "formatted_address": "2212 Country Brook Cir, Anchorage, AK 99502, USA",
-          "lat": "61.14660689999999",
-          "lng": "-149.9204609"
-        }
+        "Permit": "R23-2770",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "2212 COUNTRY BROOK, Anchorage, Alaska",
+        "Parcel": "1252612000",
+        "Units": "1",
+        "Legal": "SILVERTREE BLK 2 LT 12 G:2228",
+        "Valuation": "22307",
+        "formatted_address": "2212 Country Brook Cir, Anchorage, AK 99502, USA"
       }
     },
     {
@@ -17750,21 +15122,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2771",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "2715 KOBUK, Anchorage, Alaska",
-          "Parcel": "414349000",
-          "Units": "1",
-          "Legal": "CITY VIEW #3 BLK 6 LT 23 G:1434",
-          "Valuation": "12768",
-          "formatted_address": "2715 Kobuk Ct, Anchorage, AK 99508, USA",
-          "lat": "61.2058345",
-          "lng": "-149.8303966"
-        }
+        "Permit": "R23-2771",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "2715 KOBUK, Anchorage, Alaska",
+        "Parcel": "414349000",
+        "Units": "1",
+        "Legal": "CITY VIEW #3 BLK 6 LT 23 G:1434",
+        "Valuation": "12768",
+        "formatted_address": "2715 Kobuk Ct, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -17777,21 +15145,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2772",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "9/30/23",
-          "year": "2023",
-          "Address": "8060 RESURRECTION, Anchorage, Alaska",
-          "Parcel": "723128000",
-          "Units": "1",
-          "Legal": "CHUGACH FOOTHILLS BLK 3 LT 9 G:1741",
-          "Valuation": "31309",
-          "formatted_address": "8060 Resurrection Dr, Anchorage, AK 99504, USA",
-          "lat": "61.1810761",
-          "lng": "-149.7301361"
-        }
+        "Permit": "R23-2772",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "9/30/23",
+        "year": "2023",
+        "Address": "8060 RESURRECTION, Anchorage, Alaska",
+        "Parcel": "723128000",
+        "Units": "1",
+        "Legal": "CHUGACH FOOTHILLS BLK 3 LT 9 G:1741",
+        "Valuation": "31309",
+        "formatted_address": "8060 Resurrection Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -17804,21 +15168,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2825",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "10/31/23",
-          "year": "2023",
-          "Address": "10301 STROGANOF, Anchorage, Alaska",
-          "Parcel": "1513220000",
-          "Units": "1",
-          "Legal": "KASILOF HILLS BLK   7 LT 15  G:2541",
-          "Valuation": "27386",
-          "formatted_address": "10301 Stroganof Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1254887",
-          "lng": "-149.7179669"
-        }
+        "Permit": "R23-2825",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "10/31/23",
+        "year": "2023",
+        "Address": "10301 STROGANOF, Anchorage, Alaska",
+        "Parcel": "1513220000",
+        "Units": "1",
+        "Legal": "KASILOF HILLS BLK   7 LT 15  G:2541",
+        "Valuation": "27386",
+        "formatted_address": "10301 Stroganof Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -17831,21 +15191,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2826",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "10/31/23",
-          "year": "2023",
-          "Address": "6463 LONE TREE, Anchorage, Alaska",
-          "Parcel": "1534117000",
-          "Units": "1",
-          "Legal": "VALLI VUE ESTATES #2 BLK   3 LT 16  G:2538",
-          "Valuation": "17807",
-          "formatted_address": "6463 Lone Tree Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1319919",
-          "lng": "-149.7617517"
-        }
+        "Permit": "R23-2826",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "10/31/23",
+        "year": "2023",
+        "Address": "6463 LONE TREE, Anchorage, Alaska",
+        "Parcel": "1534117000",
+        "Units": "1",
+        "Legal": "VALLI VUE ESTATES #2 BLK   3 LT 16  G:2538",
+        "Valuation": "17807",
+        "formatted_address": "6463 Lone Tree Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -17858,21 +15214,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2832",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "10/31/23",
-          "year": "2023",
-          "Address": "1310 SHORE DRIVE, Anchorage, Alaska",
-          "Parcel": "1920105000",
-          "Units": "1",
-          "Legal": "SKYWAY PARK ESTATES #1 BLK   8 LT  6  G:2829",
-          "Valuation": "36700",
-          "formatted_address": "1310 Shore Dr, Anchorage, AK 99515, USA",
-          "lat": "61.1081768",
-          "lng": "-149.9041305"
-        }
+        "Permit": "R23-2832",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "10/31/23",
+        "year": "2023",
+        "Address": "1310 SHORE DRIVE, Anchorage, Alaska",
+        "Parcel": "1920105000",
+        "Units": "1",
+        "Legal": "SKYWAY PARK ESTATES #1 BLK   8 LT  6  G:2829",
+        "Valuation": "36700",
+        "formatted_address": "1310 Shore Dr, Anchorage, AK 99515, USA"
       }
     },
     {
@@ -17885,21 +15237,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2848",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ALASKA SOLAR LLC",
-          "Date": "10/31/23",
-          "year": "2023",
-          "Address": "2241 FOXHALL, Anchorage, Alaska",
-          "Parcel": "627220000",
-          "Units": "1",
-          "Legal": "FOXHALL #1 BLK   1 LT 49  G:1539",
-          "Valuation": "23234",
-          "formatted_address": "2241 Foxhall Dr, Anchorage, AK 99504, USA",
-          "lat": "61.200309",
-          "lng": "-149.7517153"
-        }
+        "Permit": "R23-2848",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ALASKA SOLAR LLC",
+        "Date": "10/31/23",
+        "year": "2023",
+        "Address": "2241 FOXHALL, Anchorage, Alaska",
+        "Parcel": "627220000",
+        "Units": "1",
+        "Legal": "FOXHALL #1 BLK   1 LT 49  G:1539",
+        "Valuation": "23234",
+        "formatted_address": "2241 Foxhall Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -17912,21 +15260,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R23-2894",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
-          "Date": "10/31/23",
-          "year": "2023",
-          "Address": "9600 SPRING HILL, Anchorage, Alaska",
-          "Parcel": "1505161000",
-          "Units": "1",
-          "Legal": "SPRING HILLS ESTATES BLK   2 LT 10  G:2436",
-          "Valuation": "26000",
-          "formatted_address": "9600 Spring Hill Dr, Anchorage, AK 99507, USA",
-          "lat": "61.1333443",
-          "lng": "-149.7921473"
-        }
+        "Permit": "R23-2894",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ARCTIC SOLAR VENTURES CORPORATION",
+        "Date": "10/31/23",
+        "year": "2023",
+        "Address": "9600 SPRING HILL, Anchorage, Alaska",
+        "Parcel": "1505161000",
+        "Units": "1",
+        "Legal": "SPRING HILLS ESTATES BLK   2 LT 10  G:2436",
+        "Valuation": "26000",
+        "formatted_address": "9600 Spring Hill Dr, Anchorage, AK 99507, USA"
       }
     },
     {
@@ -17939,21 +15283,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2434",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2621 REDWOOD STREET, Anchorage, Alaska",
-          "Parcel": "319424000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 17 LT 10 G:1532",
-          "Valuation": "7434",
-          "formatted_address": "2621 Redwood St, Anchorage, AK 99508, USA",
-          "lat": "61.1968168",
-          "lng": "-149.857937"
-        }
+        "Permit": "R19-2434",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2621 REDWOOD STREET, Anchorage, Alaska",
+        "Parcel": "319424000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 17 LT 10 G:1532",
+        "Valuation": "7434",
+        "formatted_address": "2621 Redwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -17966,21 +15306,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2435",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2501 NORTHRUP, Anchorage, Alaska",
-          "Parcel": "416352000",
-          "Units": "NA",
-          "Legal": "ANCHOR PARK BLK 3 LT 26 G:1534",
-          "Valuation": "8496",
-          "formatted_address": "2501 Northrup Pl, Anchorage, AK 99508, USA",
-          "lat": "61.1979717",
-          "lng": "-149.8365835"
-        }
+        "Permit": "R19-2435",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2501 NORTHRUP, Anchorage, Alaska",
+        "Parcel": "416352000",
+        "Units": "NA",
+        "Legal": "ANCHOR PARK BLK 3 LT 26 G:1534",
+        "Valuation": "8496",
+        "formatted_address": "2501 Northrup Pl, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -17993,21 +15329,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2436",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "7623 OLD HARBOR, Anchorage, Alaska",
-          "Parcel": "610106000",
-          "Units": "NA",
-          "Legal": "T13N R3W SEC 13 NE4 SW4 NE4 SW4 PTN (AKA LT 6 CREEKSIDE PARK #2) G:1340",
-          "Valuation": "8496",
-          "formatted_address": "7623 Old Harbor Ave, Anchorage, AK 99504, USA",
-          "lat": "61.2146418",
-          "lng": "-149.7382417"
-        }
+        "Permit": "R19-2436",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "7623 OLD HARBOR, Anchorage, Alaska",
+        "Parcel": "610106000",
+        "Units": "NA",
+        "Legal": "T13N R3W SEC 13 NE4 SW4 NE4 SW4 PTN (AKA LT 6 CREEKSIDE PARK #2) G:1340",
+        "Valuation": "8496",
+        "formatted_address": "7623 Old Harbor Ave, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -18020,21 +15352,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2437",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2420 GLENWOOD, Anchorage, Alaska",
-          "Parcel": "319203000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 5 LT 3 G:1533",
-          "Valuation": "8496",
-          "formatted_address": "2420 Glenwood St, Anchorage, AK 99508, USA",
-          "lat": "61.1987537",
-          "lng": "-149.85289"
-        }
+        "Permit": "R19-2437",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2420 GLENWOOD, Anchorage, Alaska",
+        "Parcel": "319203000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 5 LT 3 G:1533",
+        "Valuation": "8496",
+        "formatted_address": "2420 Glenwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18047,21 +15375,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2438",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3026 SHELDON JACKSON, Anchorage, Alaska",
-          "Parcel": "321216000",
-          "Units": "NA",
-          "Legal": "COLLEGE VILLAGE # 1 BLK 11 LT 6 G:1633",
-          "Valuation": "12272",
-          "formatted_address": "3026 Sheldon Jackson St, Anchorage, AK 99508, USA",
-          "lat": "61.19291579999999",
-          "lng": "-149.8397856"
-        }
+        "Permit": "R19-2438",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3026 SHELDON JACKSON, Anchorage, Alaska",
+        "Parcel": "321216000",
+        "Units": "NA",
+        "Legal": "COLLEGE VILLAGE # 1 BLK 11 LT 6 G:1633",
+        "Valuation": "12272",
+        "formatted_address": "3026 Sheldon Jackson St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18074,21 +15398,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2479",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3530 WINGATE, Anchorage, Alaska",
-          "Parcel": "323165000",
-          "Units": "NA",
-          "Legal": "COLLEGE VILLAGE #13 BLK 31 LT 12 G:1632",
-          "Valuation": "10338",
-          "formatted_address": "111 W Ship Creek Ave, Anchorage, AK 99501, USA",
-          "lat": "61.222874",
-          "lng": "-149.88371"
-        }
+        "Permit": "R19-2479",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3530 WINGATE, Anchorage, Alaska",
+        "Parcel": "323165000",
+        "Units": "NA",
+        "Legal": "COLLEGE VILLAGE #13 BLK 31 LT 12 G:1632",
+        "Valuation": "10338",
+        "formatted_address": "111 W Ship Creek Ave, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -18101,21 +15421,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2481",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "E 1840 24TH, Anchorage, Alaska",
-          "Parcel": "317208000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK TERRACE BLK 1 LT 2 G:1533",
-          "Valuation": "10738",
-          "formatted_address": "1840 E 24th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.19908839999999",
-          "lng": "-149.8464978"
-        }
+        "Permit": "R19-2481",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "E 1840 24TH, Anchorage, Alaska",
+        "Parcel": "317208000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK TERRACE BLK 1 LT 2 G:1533",
+        "Valuation": "10738",
+        "formatted_address": "1840 E 24th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18128,21 +15444,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2482",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2612 GLENWOOD, Anchorage, Alaska",
-          "Parcel": "319214000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 19 LT 2 G:1533",
-          "Valuation": "7434",
-          "formatted_address": "2612 Glenwood St, Anchorage, AK 99508, USA",
-          "lat": "61.1969179",
-          "lng": "-149.8529549"
-        }
+        "Permit": "R19-2482",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2612 GLENWOOD, Anchorage, Alaska",
+        "Parcel": "319214000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 19 LT 2 G:1533",
+        "Valuation": "7434",
+        "formatted_address": "2612 Glenwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18155,21 +15467,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2483",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2613 GLENWOOD, Anchorage, Alaska",
-          "Parcel": "318484000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 20 LT 10 N 20' & LT 11 S40' G:1533",
-          "Valuation": "10738",
-          "formatted_address": "2613 Glenwood St, Anchorage, AK 99508, USA",
-          "lat": "61.19691770000001",
-          "lng": "-149.8519254"
-        }
+        "Permit": "R19-2483",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2613 GLENWOOD, Anchorage, Alaska",
+        "Parcel": "318484000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 20 LT 10 N 20' & LT 11 S40' G:1533",
+        "Valuation": "10738",
+        "formatted_address": "2613 Glenwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18182,21 +15490,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2484",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "4004 MERRILL DRIVE, Anchorage, Alaska",
-          "Parcel": "1019110000",
-          "Units": "NA",
-          "Legal": "BROADMOOR ESTATES BLK 4 LT 22 G:1727",
-          "Valuation": "10738",
-          "formatted_address": "4004 Merrill Dr, Anchorage, AK 99517, USA",
-          "lat": "61.1835011",
-          "lng": "-149.9368694"
-        }
+        "Permit": "R19-2484",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "4004 MERRILL DRIVE, Anchorage, Alaska",
+        "Parcel": "1019110000",
+        "Units": "NA",
+        "Legal": "BROADMOOR ESTATES BLK 4 LT 22 G:1727",
+        "Valuation": "10738",
+        "formatted_address": "4004 Merrill Dr, Anchorage, AK 99517, USA"
       }
     },
     {
@@ -18209,21 +15513,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2570",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "E 1853 27TH, Anchorage, Alaska",
-          "Parcel": "318302000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 22 LT 3 G:1533",
-          "Valuation": "12657",
-          "formatted_address": "1853 E 27th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.19644049999999",
-          "lng": "-149.8463335"
-        }
+        "Permit": "R19-2570",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "E 1853 27TH, Anchorage, Alaska",
+        "Parcel": "318302000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 22 LT 3 G:1533",
+        "Valuation": "12657",
+        "formatted_address": "1853 E 27th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18236,21 +15536,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2572",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "E 1826 27TH, Anchorage, Alaska",
-          "Parcel": "318248000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 23 LT 3 G:1533",
-          "Valuation": "7434",
-          "formatted_address": "1826 E 27th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.19600879999999",
-          "lng": "-149.8474448"
-        }
+        "Permit": "R19-2572",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "E 1826 27TH, Anchorage, Alaska",
+        "Parcel": "318248000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 23 LT 3 G:1533",
+        "Valuation": "7434",
+        "formatted_address": "1826 E 27th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18263,21 +15559,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2573",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2423 JUNEAU, Anchorage, Alaska",
-          "Parcel": "319614000",
-          "Units": "NA",
-          "Legal": "LAMPERT #4 BLK 3 LT 10 G:1532",
-          "Valuation": "7819",
-          "formatted_address": "2423 Juneau St, Anchorage, AK 99508, USA",
-          "lat": "61.1988259",
-          "lng": "-149.8634612"
-        }
+        "Permit": "R19-2573",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2423 JUNEAU, Anchorage, Alaska",
+        "Parcel": "319614000",
+        "Units": "NA",
+        "Legal": "LAMPERT #4 BLK 3 LT 10 G:1532",
+        "Valuation": "7819",
+        "formatted_address": "2423 Juneau St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18290,21 +15582,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2574",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2961 DRAKE DRIVE, Anchorage, Alaska",
-          "Parcel": "321315000",
-          "Units": "NA",
-          "Legal": "COLLEGE VILLAGE # 3 BLK 8 LT 16 G:1633",
-          "Valuation": "11123",
-          "formatted_address": "2961 Drake Dr, Anchorage, AK 99508, USA",
-          "lat": "61.19347509999999",
-          "lng": "-149.8453371"
-        }
+        "Permit": "R19-2574",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2961 DRAKE DRIVE, Anchorage, Alaska",
+        "Parcel": "321315000",
+        "Units": "NA",
+        "Legal": "COLLEGE VILLAGE # 3 BLK 8 LT 16 G:1633",
+        "Valuation": "11123",
+        "formatted_address": "2961 Drake Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18317,21 +15605,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2694",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2441 GLENWOOD, Anchorage, Alaska",
-          "Parcel": "318461000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 6 LT 5 G:1533",
-          "Valuation": "13297",
-          "formatted_address": "2441 Glenwood St, Anchorage, AK 99508, USA",
-          "lat": "61.1983431",
-          "lng": "-149.8519553"
-        }
+        "Permit": "R19-2694",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2441 GLENWOOD, Anchorage, Alaska",
+        "Parcel": "318461000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 6 LT 5 G:1533",
+        "Valuation": "13297",
+        "formatted_address": "2441 Glenwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18344,21 +15628,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2695",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2638 REDWOOD STREET, Anchorage, Alaska",
-          "Parcel": "319511000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 16 LT 5 G:1532",
-          "Valuation": "8716",
-          "formatted_address": "2638 Redwood St, Anchorage, AK 99508, USA",
-          "lat": "61.196554",
-          "lng": "-149.85892"
-        }
+        "Permit": "R19-2695",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2638 REDWOOD STREET, Anchorage, Alaska",
+        "Parcel": "319511000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 16 LT 5 G:1532",
+        "Valuation": "8716",
+        "formatted_address": "2638 Redwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18371,21 +15651,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2696",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2744 JUNEAU, Anchorage, Alaska",
-          "Parcel": "319734000",
-          "Units": "NA",
-          "Legal": "FIREWEED MANOR BLK 4 LT 11 G:1532",
-          "Valuation": "10185",
-          "formatted_address": "2744 Juneau St, Anchorage, AK 99508, USA",
-          "lat": "61.1957128",
-          "lng": "-149.8647379"
-        }
+        "Permit": "R19-2696",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2744 JUNEAU, Anchorage, Alaska",
+        "Parcel": "319734000",
+        "Units": "NA",
+        "Legal": "FIREWEED MANOR BLK 4 LT 11 G:1532",
+        "Valuation": "10185",
+        "formatted_address": "2744 Juneau St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18398,21 +15674,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2697",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1813 ROGERS PARK COURT, Anchorage, Alaska",
-          "Parcel": "318353000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 8 LT 8A G:1533",
-          "Valuation": "11548",
-          "formatted_address": "1813 Rogers Park Ct, Anchorage, AK 99508, USA",
-          "lat": "61.19857640000001",
-          "lng": "-149.8480571"
-        }
+        "Permit": "R19-2697",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1813 ROGERS PARK COURT, Anchorage, Alaska",
+        "Parcel": "318353000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 8 LT 8A G:1533",
+        "Valuation": "11548",
+        "formatted_address": "1813 Rogers Park Ct, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18425,21 +15697,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2698",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2617 KARLUK, Anchorage, Alaska",
-          "Parcel": "319815000",
-          "Units": "NA",
-          "Legal": "FIREWEED MANOR BLK 1 LT 11 G:1532",
-          "Valuation": "11233",
-          "formatted_address": "2617 Karluk St, Anchorage, AK 99508, USA",
-          "lat": "61.1970293",
-          "lng": "-149.8612703"
-        }
+        "Permit": "R19-2698",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2617 KARLUK, Anchorage, Alaska",
+        "Parcel": "319815000",
+        "Units": "NA",
+        "Legal": "FIREWEED MANOR BLK 1 LT 11 G:1532",
+        "Valuation": "11233",
+        "formatted_address": "2617 Karluk St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18452,21 +15720,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2705",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2613 COTTONWOOD, Anchorage, Alaska",
-          "Parcel": "319223000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 19 LT 11 G:1532",
-          "Valuation": "7434",
-          "formatted_address": "2613 Cottonwood St, Anchorage, AK 99508, USA",
-          "lat": "61.1969457",
-          "lng": "-149.854218"
-        }
+        "Permit": "R19-2705",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2613 COTTONWOOD, Anchorage, Alaska",
+        "Parcel": "319223000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 19 LT 11 G:1532",
+        "Valuation": "7434",
+        "formatted_address": "2613 Cottonwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18479,21 +15743,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2706",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2667 NORTHRUP CIRCLE, Anchorage, Alaska",
-          "Parcel": "416341000",
-          "Units": "NA",
-          "Legal": "ANCHOR PARK BLK 3 LT 15 G:1534",
-          "Valuation": "7709",
-          "formatted_address": "2667 Northrup Cir, Anchorage, AK 99508, USA",
-          "lat": "61.19855219999999",
-          "lng": "-149.8371622"
-        }
+        "Permit": "R19-2706",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2667 NORTHRUP CIRCLE, Anchorage, Alaska",
+        "Parcel": "416341000",
+        "Units": "NA",
+        "Legal": "ANCHOR PARK BLK 3 LT 15 G:1534",
+        "Valuation": "7709",
+        "formatted_address": "2667 Northrup Cir, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18506,21 +15766,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2707",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2630 DARBY CIRCLE, Anchorage, Alaska",
-          "Parcel": "416211000",
-          "Units": "NA",
-          "Legal": "ANCHOR PARK BLK 1 LT 37 G:1534",
-          "Valuation": "8496",
-          "formatted_address": "2630 Darby Cir, Anchorage, AK 99508, USA",
-          "lat": "61.1960597",
-          "lng": "-149.8328687"
-        }
+        "Permit": "R19-2707",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2630 DARBY CIRCLE, Anchorage, Alaska",
+        "Parcel": "416211000",
+        "Units": "NA",
+        "Legal": "ANCHOR PARK BLK 1 LT 37 G:1534",
+        "Valuation": "8496",
+        "formatted_address": "2630 Darby Cir, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18533,21 +15789,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2708",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "3000 WENTWORTH STREET, Anchorage, Alaska",
-          "Parcel": "321518000",
-          "Units": "NA",
-          "Legal": "COLLEGE VILLAGE # 5 BLK 17 LT 1A G:1633",
-          "Valuation": "11663",
-          "formatted_address": "3000 Wentworth St, Anchorage, AK 99508, USA",
-          "lat": "61.19282589999999",
-          "lng": "-149.8527566"
-        }
+        "Permit": "R19-2708",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "3000 WENTWORTH STREET, Anchorage, Alaska",
+        "Parcel": "321518000",
+        "Units": "NA",
+        "Legal": "COLLEGE VILLAGE # 5 BLK 17 LT 1A G:1633",
+        "Valuation": "11663",
+        "formatted_address": "3000 Wentworth St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18560,21 +15812,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2709",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2414 NORTHRUP CIRCLE, Anchorage, Alaska",
-          "Parcel": "416239000",
-          "Units": "NA",
-          "Legal": "ANCHOR PARK BLK 1 LT 1 G:1534",
-          "Valuation": "7659",
-          "formatted_address": "2414 Northrup Cir, Anchorage, AK 99508, USA",
-          "lat": "61.198347",
-          "lng": "-149.8375183"
-        }
+        "Permit": "R19-2709",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2414 NORTHRUP CIRCLE, Anchorage, Alaska",
+        "Parcel": "416239000",
+        "Units": "NA",
+        "Legal": "ANCHOR PARK BLK 1 LT 1 G:1534",
+        "Valuation": "7659",
+        "formatted_address": "2414 Northrup Cir, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18587,21 +15835,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2710",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "E 1852 24TH, Anchorage, Alaska",
-          "Parcel": "317209000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK TERRACE BLK 1 LT 1 G:1533",
-          "Valuation": "7759",
-          "formatted_address": "1852 E 24th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.19903739999999",
-          "lng": "-149.8461902"
-        }
+        "Permit": "R19-2710",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "E 1852 24TH, Anchorage, Alaska",
+        "Parcel": "317209000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK TERRACE BLK 1 LT 1 G:1533",
+        "Valuation": "7759",
+        "formatted_address": "1852 E 24th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18614,21 +15858,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2724",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1834 SUNRISE, Anchorage, Alaska",
-          "Parcel": "414213000",
-          "Units": "NA",
-          "Legal": "SAXTON BLK 7 LT 14 G:1434",
-          "Valuation": "38923",
-          "formatted_address": "1834 Sunrise Dr, Anchorage, AK 99508, USA",
-          "lat": "61.2037093",
-          "lng": "-149.8268552"
-        }
+        "Permit": "R19-2724",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1834 SUNRISE, Anchorage, Alaska",
+        "Parcel": "414213000",
+        "Units": "NA",
+        "Legal": "SAXTON BLK 7 LT 14 G:1434",
+        "Valuation": "38923",
+        "formatted_address": "1834 Sunrise Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18641,21 +15881,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2725",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "1543 BANNISTER, Anchorage, Alaska",
-          "Parcel": "316101000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 1 LT 23 G:1533",
-          "Valuation": "22750",
-          "formatted_address": "1543 Bannister Dr, Anchorage, AK 99508, USA",
-          "lat": "61.1994706",
-          "lng": "-149.8525255"
-        }
+        "Permit": "R19-2725",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "1543 BANNISTER, Anchorage, Alaska",
+        "Parcel": "316101000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 1 LT 23 G:1533",
+        "Valuation": "22750",
+        "formatted_address": "1543 Bannister Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18668,21 +15904,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2726",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2069 DUKE, Anchorage, Alaska",
-          "Parcel": "322103000",
-          "Units": "NA",
-          "Legal": "COLLEGE VILLAGE # 8 BLK 21 LT 3 G:1633",
-          "Valuation": "30680",
-          "formatted_address": "2069 Duke Dr, Anchorage, AK 99508, USA",
-          "lat": "61.19072490000001",
-          "lng": "-149.8412994"
-        }
+        "Permit": "R19-2726",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2069 DUKE, Anchorage, Alaska",
+        "Parcel": "322103000",
+        "Units": "NA",
+        "Legal": "COLLEGE VILLAGE # 8 BLK 21 LT 3 G:1633",
+        "Valuation": "30680",
+        "formatted_address": "2069 Duke Dr, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18695,21 +15927,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2727",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "E 1601 26TH, Anchorage, Alaska",
-          "Parcel": "318454000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 11 LT 7 G:1533",
-          "Valuation": "12588",
-          "formatted_address": "1601 E 26th Ave, Anchorage, AK 99508, USA",
-          "lat": "61.1973743",
-          "lng": "-149.8519904"
-        }
+        "Permit": "R19-2727",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "E 1601 26TH, Anchorage, Alaska",
+        "Parcel": "318454000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 11 LT 7 G:1533",
+        "Valuation": "12588",
+        "formatted_address": "1601 E 26th Ave, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18722,21 +15950,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2728",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "6010 CRAIG DRIVE, Anchorage, Alaska",
-          "Parcel": "623148000",
-          "Units": "NA",
-          "Legal": "NUNAKA VALLEY BLK W LT 16 G:1438",
-          "Valuation": "8496",
-          "formatted_address": "6010 Craig Dr, Anchorage, AK 99504, USA",
-          "lat": "61.2026945",
-          "lng": "-149.7706294"
-        }
+        "Permit": "R19-2728",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "6010 CRAIG DRIVE, Anchorage, Alaska",
+        "Parcel": "623148000",
+        "Units": "NA",
+        "Legal": "NUNAKA VALLEY BLK W LT 16 G:1438",
+        "Valuation": "8496",
+        "formatted_address": "6010 Craig Dr, Anchorage, AK 99504, USA"
       }
     },
     {
@@ -18749,21 +15973,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2729",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2510 SPRUCEWOOD, Anchorage, Alaska",
-          "Parcel": "319411000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 14 LT 3 G:1532",
-          "Valuation": "7899",
-          "formatted_address": "2510 Sprucewood St, Anchorage, AK 99508, USA",
-          "lat": "61.1978164",
-          "lng": "-149.8572873"
-        }
+        "Permit": "R19-2729",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2510 SPRUCEWOOD, Anchorage, Alaska",
+        "Parcel": "319411000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 14 LT 3 G:1532",
+        "Valuation": "7899",
+        "formatted_address": "2510 Sprucewood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18776,21 +15996,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2730",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2526 GALEWOOD, Anchorage, Alaska",
-          "Parcel": "318435000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 11 LT 4 G:1533",
-          "Valuation": "9331",
-          "formatted_address": "2526 Galewood St, Anchorage, AK 99508, USA",
-          "lat": "61.1976557",
-          "lng": "-149.850878"
-        }
+        "Permit": "R19-2730",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2526 GALEWOOD, Anchorage, Alaska",
+        "Parcel": "318435000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 11 LT 4 G:1533",
+        "Valuation": "9331",
+        "formatted_address": "2526 Galewood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18803,21 +16019,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2736",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2535 GLENWOOD, Anchorage, Alaska",
-          "Parcel": "318455000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 11 LT 8 G:1533",
-          "Valuation": "9341",
-          "formatted_address": "2535 Glenwood St, Anchorage, AK 99508, USA",
-          "lat": "61.1975253",
-          "lng": "-149.8519899"
-        }
+        "Permit": "R19-2736",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2535 GLENWOOD, Anchorage, Alaska",
+        "Parcel": "318455000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 11 LT 8 G:1533",
+        "Valuation": "9341",
+        "formatted_address": "2535 Glenwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18830,21 +16042,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2737",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2433 GLENWOOD, Anchorage, Alaska",
-          "Parcel": "318462000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 6 LT 6 G:1533",
-          "Valuation": "10295",
-          "formatted_address": "2433 Glenwood St, Anchorage, AK 99508, USA",
-          "lat": "61.19846459999999",
-          "lng": "-149.8520704"
-        }
+        "Permit": "R19-2737",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2433 GLENWOOD, Anchorage, Alaska",
+        "Parcel": "318462000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 6 LT 6 G:1533",
+        "Valuation": "10295",
+        "formatted_address": "2433 Glenwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18857,21 +16065,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2738",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "E 1435 26TH, Anchorage, Alaska",
-          "Parcel": "319315000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 13 LT 6 G:1532",
-          "Valuation": "7959",
-          "formatted_address": "1435 E St, Anchorage, AK 99501, USA",
-          "lat": "61.20836929999999",
-          "lng": "-149.8914576"
-        }
+        "Permit": "R19-2738",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "E 1435 26TH, Anchorage, Alaska",
+        "Parcel": "319315000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 13 LT 6 G:1532",
+        "Valuation": "7959",
+        "formatted_address": "1435 E St, Anchorage, AK 99501, USA"
       }
     },
     {
@@ -18884,21 +16088,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R19-2929",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "2019",
-          "year": "2019",
-          "Address": "2421 REDWOOD STREET, Anchorage, Alaska",
-          "Parcel": "319443000",
-          "Units": "NA",
-          "Legal": "ROGERS PARK BLK 14 LT 11 N2 & LT 12 G:1532",
-          "Valuation": "11123",
-          "formatted_address": "2421 Redwood St, Anchorage, AK 99508, USA",
-          "lat": "61.19816040000001",
-          "lng": "-149.8581673"
-        }
+        "Permit": "R19-2929",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "2019",
+        "year": "2019",
+        "Address": "2421 REDWOOD STREET, Anchorage, Alaska",
+        "Parcel": "319443000",
+        "Units": "NA",
+        "Legal": "ROGERS PARK BLK 14 LT 11 N2 & LT 12 G:1532",
+        "Valuation": "11123",
+        "formatted_address": "2421 Redwood St, Anchorage, AK 99508, USA"
       }
     },
     {
@@ -18911,21 +16111,17 @@
         ]
       },
       "properties": {
-        "properties": {
-          "Permit": "R20-1001",
-          "Worktype": "BldgAlter",
-          "IssuedTo": "ABS ALASKAN INC",
-          "Date": "1/31/2020",
-          "year": "2020",
-          "Address": "3132 SUNFLOWER STREET, Anchorage, Alaska",
-          "Parcel": "511341000",
-          "Units": "0",
-          "Legal": "COLLEGEGATE #5A BLK 7 LT 18 G:1637",
-          "Valuation": "10435",
-          "formatted_address": "3132 Sunflower St, Anchorage, AK 99508, USA",
-          "lat": "61.192061699999996",
-          "lng": "-149.7856115"
-        }
+        "Permit": "R20-1001",
+        "Worktype": "BldgAlter",
+        "IssuedTo": "ABS ALASKAN INC",
+        "Date": "1/31/2020",
+        "year": "2020",
+        "Address": "3132 SUNFLOWER STREET, Anchorage, Alaska",
+        "Parcel": "511341000",
+        "Units": "0",
+        "Legal": "COLLEGEGATE #5A BLK 7 LT 18 G:1637",
+        "Valuation": "10435",
+        "formatted_address": "3132 Sunflower St, Anchorage, AK 99508, USA"
       }
     }
   ]


### PR DESCRIPTION
during the conversion from csv to geojson, the script `csv_to_geojson.js` wrote an additional nested property, resulting in situations like this: `features.properties.properties.Name`. Not ideal. Fixed with this PR.